### PR TITLE
Use NextResponse.redirect for login success

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -14,11 +14,18 @@ export async function POST(req: NextRequest) {
   const ok = await bcrypt.compare(password, user.passwordHash);
   if (!ok) return NextResponse.json({ error: 'Invalid' }, { status: 400 });
 
-  const res = new NextResponse(null, { status: 302, headers: { Location: '/seller/dashboard' } });
+  const redirectTo = new URL('/seller/dashboard', req.url);
+  const res = new NextResponse();
   const session = await getIronSession<{ user?: SessionUser }>(req, res, sessionOptions);
   session.user = { id: user.id, name: user.name, email: user.email, slug: user.slug, isAdmin: user.isAdmin };
   await session.save();
-  return res;
+  const redirectResponse = NextResponse.redirect(redirectTo);
+  res.headers.forEach((value, key) => {
+    if (key.toLowerCase() === 'set-cookie') {
+      redirectResponse.headers.append(key, value);
+    }
+  });
+  return redirectResponse;
 }
 
 


### PR DESCRIPTION
## Summary
- replace the manual redirect in the login API with `NextResponse.redirect`
- ensure the session cookies from the iron-session response are preserved when redirecting

## Testing
- npm run build *(fails: DATABASE_URL environment variable not configured in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e094cfe5d08320b92ad1c0ab1e7aae