### PR TITLE
Guard strike-through pricing against null values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+.next/
+.env
+.env.*
+
+# Prisma
+prisma/migrations/

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -14,11 +14,18 @@ export async function POST(req: NextRequest) {
   const ok = await bcrypt.compare(password, user.passwordHash);
   if (!ok) return NextResponse.json({ error: 'Invalid' }, { status: 400 });
 
-  const res = new NextResponse(null, { status: 302, headers: { Location: '/seller/dashboard' } });
+  const redirectTo = new URL('/seller/dashboard', req.url);
+  const res = new NextResponse();
   const session = await getIronSession<{ user?: SessionUser }>(req, res, sessionOptions);
   session.user = { id: user.id, name: user.name, email: user.email, slug: user.slug, isAdmin: user.isAdmin };
   await session.save();
-  return res;
+  const redirectResponse = NextResponse.redirect(redirectTo);
+  res.headers.forEach((value, key) => {
+    if (key.toLowerCase() === 'set-cookie') {
+      redirectResponse.headers.append(key, value);
+    }
+  });
+  return redirectResponse;
 }
 
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import "./globals.css";
+import { SiteFooter } from "@/components/SiteFooter";
 
 export const metadata = {
   title: "Akay Nusantara",
@@ -10,20 +11,17 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="id">
       <body className="bg-gray-50 text-gray-900">
         <header className="bg-white border-b border-army/20">
-          <div className="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
-            <a href="/" className="font-bold text-xl text-army">🛍️ Akay Nusantara</a>
-            <nav className="flex gap-4 items-center text-sm">
-              <a href="/cart" className="hover:underline text-army">Keranjang</a>
-              <a href="/seller/login" className="hover:underline text-army">Seller</a>
-              <a href="/admin/orders" className="hover:underline text-army">Admin</a>
+          <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
+            <a href="/" className="text-xl font-bold text-army">🛍️ Akay Nusantara</a>
+            <nav className="flex items-center gap-4 text-sm">
+              <a href="/cart" className="text-army hover:underline">Keranjang</a>
+              <a href="/seller/login" className="text-army hover:underline">Seller</a>
+              <a href="/admin/orders" className="text-army hover:underline">Admin</a>
             </nav>
           </div>
         </header>
-        <main className="max-w-6xl mx-auto px-4 py-6">{children}</main>
-        <footer className="border-t py-8 text-sm text-center text-gray-600">
-          Transfer ke: <b>{process.env.BANK_NAME} - {process.env.ACCOUNT_NAME}</b> | No.Rek: <b>{process.env.BANK_ACCOUNT}</b>
-          <div className="mt-2">© {new Date().getFullYear()} Akay Nusantara</div>
-        </footer>
+        <main className="mx-auto max-w-6xl px-4 py-6">{children}</main>
+        <SiteFooter />
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,9 @@
+import Link from "next/link";
+
 import { prisma } from "@/lib/prisma";
 import { formatIDR } from "@/lib/utils";
+import { PromoSlider } from "@/components/PromoSlider";
+import { getCategoryInfo, productCategories } from "@/lib/categories";
 
 export default async function HomePage() {
   const products = await prisma.product.findMany({
@@ -7,21 +11,83 @@ export default async function HomePage() {
     orderBy: { createdAt: 'desc' },
     include: { seller: true }
   });
+  const categories = productCategories;
   return (
-    <div>
-      <h1 className="text-2xl font-semibold mb-4">Produk Terbaru</h1>
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        {products.map(p => (
-          <a key={p.id} href={`/product/${p.id}`} className="border bg-white rounded-lg overflow-hidden hover:shadow">
-            <img src={p.imageUrl || 'https://placehold.co/600x400?text=Produk'} className="w-full h-40 object-cover" />
-            <div className="p-3">
-              <div className="font-medium line-clamp-1">{p.title}</div>
-              <div className="text-sm text-gray-500">Seller: <a className="underline" href={`/s/${p.seller.slug}`}>{p.seller.name}</a></div>
-              <div className="mt-1 font-semibold">Rp {formatIDR(p.price)}</div>
-            </div>
-          </a>
-        ))}
-      </div>
+    <div className="space-y-10">
+      <PromoSlider />
+
+      <section>
+        <h2 className="mb-4 text-xl font-semibold">Kategori Populer</h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-6">
+          {categories.map(category => (
+            <Link
+              key={category.slug}
+              href={`/?category=${category.slug}`}
+              className="group rounded-xl border bg-white p-4 text-center shadow-sm transition hover:-translate-y-1 hover:shadow-md"
+            >
+              <div className="text-2xl">{category.emoji}</div>
+              <div className="mt-2 font-semibold text-gray-800">{category.name}</div>
+              <div className="text-xs text-gray-500 transition group-hover:text-gray-700">
+                {category.description}
+              </div>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <div className="mb-4 flex items-center justify-between">
+          <h1 className="text-2xl font-semibold">Produk Terbaru</h1>
+          <Link
+            href="/product"
+            className="text-sm font-medium text-indigo-600 hover:text-indigo-500"
+          >
+            Lihat semua
+          </Link>
+        </div>
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+          {products.map(p => {
+            const category = getCategoryInfo(p.category);
+            const originalPrice = typeof p.originalPrice === 'number' ? p.originalPrice : null;
+            const showOriginal = originalPrice !== null && originalPrice > p.price;
+            const categoryLabel = category?.name ?? p.category.replace(/-/g, ' ');
+            const categoryEmoji = category?.emoji ?? '🏷️';
+            return (
+              <div
+                key={p.id}
+                className="overflow-hidden rounded-lg border bg-white shadow transition hover:-translate-y-1 hover:shadow-lg"
+              >
+                <Link href={`/product/${p.id}`} className="block">
+                  <img
+                    src={p.imageUrl || 'https://placehold.co/600x400?text=Produk'}
+                    className="h-40 w-full object-cover"
+                    alt={p.title}
+                  />
+                </Link>
+                <div className="p-3">
+                  <div className="mb-1 inline-flex items-center gap-1 rounded-full bg-indigo-50 px-3 py-1 text-xs font-medium text-indigo-600">
+                    <span>{categoryEmoji}</span>
+                    <span className="capitalize">{categoryLabel}</span>
+                  </div>
+                  <Link href={`/product/${p.id}`} className="font-medium line-clamp-1 hover:text-indigo-600">
+                    {p.title}
+                  </Link>
+                  <div className="text-sm text-gray-500">
+                    Seller:{' '}
+                    <Link className="underline hover:text-indigo-600" href={`/s/${p.seller.slug}`}>
+                      {p.seller.name}
+                    </Link>
+                  </div>
+                  {showOriginal && (
+                    <div className="text-xs text-gray-400 line-through">Rp {formatIDR(originalPrice)}</div>
+                  )}
+                  <div className="mt-1 text-lg font-semibold text-indigo-600">Rp {formatIDR(p.price)}</div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
     </div>
   );
 }

--- a/app/product/[id]/page.tsx
+++ b/app/product/[id]/page.tsx
@@ -1,25 +1,49 @@
 import { prisma } from "@/lib/prisma";
 import { formatIDR } from "@/lib/utils";
+import { getCategoryInfo } from "@/lib/categories";
 
 export default async function ProductPage({ params }: { params: { id: string } }) {
   const product = await prisma.product.findUnique({ where: { id: params.id }, include: { seller: true, warehouse: true } });
   if (!product) return <div>Produk tidak ditemukan</div>;
+
+  const category = getCategoryInfo(product.category);
+  const originalPrice = typeof product.originalPrice === 'number' ? product.originalPrice : null;
+  const showOriginal = originalPrice !== null && originalPrice > product.price;
+  const categoryLabel = category?.name ?? product.category.replace(/-/g, ' ');
+  const categoryEmoji = category?.emoji ?? '🏷️';
+
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+    <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
       <div>
         <img src={product.imageUrl || 'https://placehold.co/800x600?text=Produk'} className="w-full rounded-lg border" />
       </div>
       <div>
         <h1 className="text-2xl font-semibold">{product.title}</h1>
-        <div className="text-sm text-gray-500">Seller: <a className="underline" href={`/s/${product.seller.slug}`}>{product.seller.name}</a></div>
-        <div className="text-xs text-gray-500">{product.warehouse ? `Gudang: ${product.warehouse.name}${product.warehouse.city? ' - '+product.warehouse.city:''}` : 'Gudang: -'}</div>
-        <div className="mt-2 text-xl font-bold">Rp {formatIDR(product.price)}</div>
+        <div className="mt-1 inline-flex items-center gap-1 rounded-full bg-indigo-50 px-3 py-1 text-xs font-medium text-indigo-600">
+          <span>{categoryEmoji}</span>
+          <span className="capitalize">{categoryLabel}</span>
+        </div>
+        <div className="text-sm text-gray-500">
+          Seller:{' '}
+          <a className="underline" href={`/s/${product.seller.slug}`}>
+            {product.seller.name}
+          </a>
+        </div>
+        <div className="text-xs text-gray-500">
+          {product.warehouse
+            ? `Gudang: ${product.warehouse.name}${product.warehouse.city ? ' - ' + product.warehouse.city : ''}`
+            : 'Gudang: -'}
+        </div>
+        {showOriginal && (
+          <div className="mt-2 text-sm text-gray-400 line-through">Rp {formatIDR(originalPrice)}</div>
+        )}
+        <div className="mt-1 text-2xl font-bold text-indigo-600">Rp {formatIDR(product.price)}</div>
         <p className="mt-3 text-gray-700">{product.description || ''}</p>
         <form className="mt-4" method="POST" action="/api/cart/add">
           <input type="hidden" name="productId" value={product.id} />
-          <label className="block text-sm mb-1">Jumlah</label>
-          <input type="number" name="qty" defaultValue={1} min={1} className="border rounded px-3 py-2 w-24" />
-          <button className="ml-2 btn-primary">+ Keranjang</button>
+          <label className="mb-1 block text-sm">Jumlah</label>
+          <input type="number" name="qty" defaultValue={1} min={1} className="w-24 rounded border px-3 py-2" />
+          <button className="btn-primary ml-2">+ Keranjang</button>
         </form>
       </div>
     </div>

--- a/app/s/[slug]/page.tsx
+++ b/app/s/[slug]/page.tsx
@@ -1,4 +1,6 @@
 import { prisma } from "@/lib/prisma";
+import { getCategoryInfo } from "@/lib/categories";
+import { formatIDR } from "@/lib/utils";
 
 export default async function Storefront({ params }: { params: { slug: string } }) {
   const seller = await prisma.user.findUnique({ where: { slug: params.slug } });
@@ -7,17 +9,31 @@ export default async function Storefront({ params }: { params: { slug: string } 
   return (
     <div>
       <h1 className="text-2xl font-semibold mb-4">Toko {seller.name}</h1>
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        {products.map(p => (
-          <a key={p.id} href={`/product/${p.id}`} className="border bg-white rounded-lg overflow-hidden hover:shadow">
-            <img src={p.imageUrl || 'https://placehold.co/600x400?text=Produk'} className="w-full h-40 object-cover" />
-            <div className="p-3">
-              <div className="font-medium line-clamp-1">{p.title}</div>
-              <div className="mt-1 font-semibold">Rp {new Intl.NumberFormat('id-ID').format(p.price)}</div>
-            </div>
-          </a>
-        ))}
-      </div>
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+          {products.map(p => {
+            const category = getCategoryInfo(p.category);
+            const categoryLabel = category?.name ?? p.category.replace(/-/g, ' ');
+            const categoryEmoji = category?.emoji ?? '🏷️';
+            const originalPrice = typeof p.originalPrice === 'number' ? p.originalPrice : null;
+            const showOriginal = originalPrice !== null && originalPrice > p.price;
+            return (
+              <a key={p.id} href={`/product/${p.id}`} className="overflow-hidden rounded-lg border bg-white transition hover:-translate-y-1 hover:shadow-lg">
+                <img src={p.imageUrl || 'https://placehold.co/600x400?text=Produk'} className="h-40 w-full object-cover" />
+                <div className="p-3">
+                  <div className="mb-1 inline-flex items-center gap-1 rounded-full bg-indigo-50 px-3 py-1 text-xs font-medium text-indigo-600">
+                    <span>{categoryEmoji}</span>
+                    <span className="capitalize">{categoryLabel}</span>
+                  </div>
+                  <div className="font-medium line-clamp-1">{p.title}</div>
+                  {showOriginal && (
+                    <div className="text-xs text-gray-400 line-through">Rp {formatIDR(originalPrice)}</div>
+                  )}
+                  <div className="mt-1 text-lg font-semibold text-indigo-600">Rp {formatIDR(p.price)}</div>
+                </div>
+              </a>
+            );
+          })}
+        </div>
     </div>
   );
 }

--- a/app/seller/products/page.tsx
+++ b/app/seller/products/page.tsx
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { cookies } from "next/headers";
 import { sessionOptions, SessionUser } from "@/lib/session";
 import { getIronSession } from "iron-session";
+import { productCategories, getCategoryInfo } from "@/lib/categories";
 
 export const dynamic = 'force-dynamic';
 
@@ -22,18 +23,34 @@ export default async function SellerProducts() {
     prisma.warehouse.findMany({ where: { ownerId: user.id }, orderBy: { createdAt: 'desc' } })
   ]);
 
+  const categoryLabel = (slug: string) => getCategoryInfo(slug)?.name ?? slug.replace(/-/g, ' ');
+
   return (
     <div>
       <h1 className="text-2xl font-semibold mb-4">Produk Saya</h1>
       <div className="bg-white border rounded p-4 mb-6">
         <h2 className="font-semibold mb-2">Tambah Produk</h2>
         <form method="POST" action="/api/seller/products/create" className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <select name="category" required className="border rounded px-3 py-2 md:col-span-2">
+            <option value="">Pilih Kategori Produk</option>
+            {productCategories.map((category) => (
+              <option key={category.slug} value={category.slug}>
+                {category.emoji} {category.name}
+              </option>
+            ))}
+          </select>
           <select name="warehouseId" className="border rounded px-3 py-2 md:col-span-2">
             <option value="">Pilih Gudang (opsional)</option>
             {warehouses.map(w => (<option key={w.id} value={w.id}>{w.name} {w.city?`- ${w.city}`:''}</option>))}
           </select>
           <input name="title" required placeholder="Judul produk" className="border rounded px-3 py-2"/>
           <input name="price" required type="number" placeholder="Harga (integer)" className="border rounded px-3 py-2"/>
+          <input
+            name="originalPrice"
+            type="number"
+            placeholder="Harga sebelum diskon (opsional)"
+            className="border rounded px-3 py-2"
+          />
           <input name="stock" type="number" placeholder="Stok" className="border rounded px-3 py-2"/>
           <input name="imageUrl" placeholder="URL gambar" className="border rounded px-3 py-2"/>
           <textarea name="description" placeholder="Deskripsi" className="border rounded px-3 py-2 md:col-span-2"></textarea>
@@ -42,12 +59,24 @@ export default async function SellerProducts() {
       </div>
       <div className="bg-white border rounded p-4">
         <table className="w-full text-sm">
-          <thead><tr className="text-left border-b"><th className="py-2">Produk</th><th>Harga</th><th>Stok</th><th>Status</th><th>Aksi</th></tr></thead>
+          <thead>
+            <tr className="text-left border-b">
+              <th className="py-2">Produk</th>
+              <th>Kategori</th>
+              <th>Harga</th>
+              <th>Harga Coret</th>
+              <th>Stok</th>
+              <th>Status</th>
+              <th>Aksi</th>
+            </tr>
+          </thead>
           <tbody>
             {products.map(p => (
               <tr key={p.id} className="border-b">
                 <td className="py-2">{p.title}<div className="text-xs text-gray-500">{p.warehouse ? `Gudang: ${p.warehouse.name}` : 'Gudang: -'}</div></td>
+                <td>{categoryLabel(p.category)}</td>
                 <td>Rp {new Intl.NumberFormat('id-ID').format(p.price)}</td>
+                <td>{p.originalPrice ? `Rp ${new Intl.NumberFormat('id-ID').format(p.originalPrice)}` : '-'}</td>
                 <td>{p.stock}</td>
                 <td><span className={`badge ${p.isActive ? 'badge-paid':'badge-pending'}`}>{p.isActive ? 'Aktif':'Nonaktif'}</span></td>
                 <td className="space-x-2">

--- a/components/PromoSlider.tsx
+++ b/components/PromoSlider.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+
+type Slide = {
+  title: string;
+  description: string;
+  highlight: string;
+  imageUrl: string;
+  ctaLabel: string;
+  ctaHref: string;
+};
+
+export function PromoSlider({ className }: { className?: string }) {
+  const slides = useMemo<Slide[]>(
+    () => [
+      {
+        title: "Promo Spesial Minggu Ini",
+        description: "Nikmati potongan harga hingga 40% untuk produk pilihan.",
+        highlight: "Diskon Terbatas",
+        imageUrl: "https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=1200&q=80",
+        ctaLabel: "Belanja Sekarang",
+        ctaHref: "/product"
+      },
+      {
+        title: "Gratis Ongkir ke Seluruh Indonesia",
+        description: "Belanja sekarang dan dapatkan pengiriman gratis tanpa minimum belanja.",
+        highlight: "Ongkir 0 Rupiah",
+        imageUrl: "https://images.unsplash.com/photo-1523275335684-37898b6baf30?auto=format&fit=crop&w=1200&q=80",
+        ctaLabel: "Lihat Promo",
+        ctaHref: "/product"
+      },
+      {
+        title: "Flash Sale Setiap Hari",
+        description: "Produk favorit dengan harga spesial hadir setiap hari jam 12.00-15.00.",
+        highlight: "3 Jam Saja",
+        imageUrl: "https://images.unsplash.com/photo-1483478550801-ceba5fe50e8e?auto=format&fit=crop&w=1200&q=80",
+        ctaLabel: "Ikuti Flash Sale",
+        ctaHref: "/product"
+      }
+    ],
+    []
+  );
+
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setActiveIndex((prev) => (prev + 1) % slides.length);
+    }, 6000);
+
+    return () => clearInterval(interval);
+  }, [slides.length]);
+
+  return (
+    <div
+      className={`relative overflow-hidden rounded-2xl bg-gradient-to-r from-indigo-600 via-purple-600 to-pink-500 text-white shadow-lg ${
+        className ?? ""
+      }`}
+    >
+      <div className="relative min-h-[240px]">
+        {slides.map((slide, index) => (
+          <div
+            key={slide.title}
+            className={`absolute inset-0 flex flex-col gap-6 p-8 transition-all duration-700 ease-in-out md:flex-row md:items-center ${
+              index === activeIndex
+                ? "opacity-100 translate-x-0"
+                : "pointer-events-none -translate-x-12 opacity-0"
+            }`}
+          >
+            <div className="flex-1 space-y-3">
+              <span className="inline-flex items-center rounded-full bg-white/20 px-4 py-1 text-sm font-semibold uppercase tracking-wide">
+                {slide.highlight}
+              </span>
+              <h2 className="text-3xl font-bold leading-tight md:text-4xl">
+                {slide.title}
+              </h2>
+              <p className="max-w-xl text-sm md:text-base md:leading-relaxed">
+                {slide.description}
+              </p>
+              <Link
+                href={slide.ctaHref}
+                className="inline-flex w-fit items-center justify-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-indigo-600 transition hover:bg-indigo-50"
+              >
+                {slide.ctaLabel}
+              </Link>
+            </div>
+            <div className="relative flex-1">
+              <div className="absolute inset-0 rounded-xl bg-black/20" />
+              <img
+                src={slide.imageUrl}
+                alt={slide.title}
+                className="h-48 w-full rounded-xl object-cover shadow-lg md:h-64"
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="absolute bottom-4 left-0 right-0 flex items-center justify-center gap-2">
+        {slides.map((slide, index) => (
+          <button
+            key={slide.title}
+            className={`h-2.5 rounded-full transition-all duration-300 ${
+              index === activeIndex ? "w-8 bg-white" : "w-2 bg-white/60 hover:bg-white"
+            }`}
+            aria-label={`Tampilkan slide ${index + 1}`}
+            onClick={() => setActiveIndex(index)}
+            type="button"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/components/SiteFooter.tsx
+++ b/components/SiteFooter.tsx
@@ -1,0 +1,187 @@
+import Link from "next/link";
+
+const customerServiceLinks = [
+  { label: "Bantuan", href: "#" },
+  { label: "Metode Pembayaran", href: "#" },
+  { label: "AkayPay", href: "#" },
+  { label: "Koin Akay", href: "#" },
+  { label: "Lacak Pesanan Pembeli", href: "#" },
+  { label: "Lacak Pengiriman Penjual", href: "#" },
+  { label: "Gratis Ongkir", href: "#" },
+  { label: "Pengembalian Barang & Dana", href: "#" },
+  { label: "Hubungi Kami", href: "#" }
+];
+
+const exploreLinks = [
+  { label: "Tentang Kami", href: "#" },
+  { label: "Karir", href: "#" },
+  { label: "Kebijakan Privasi", href: "#" },
+  { label: "Blog", href: "#" },
+  { label: "Akay Mall", href: "#" },
+  { label: "Seller Center", href: "#" },
+  { label: "Menjadi Mitra", href: "#" },
+  { label: "Logistik Kami", href: "#" },
+  { label: "Kanal Media", href: "#" }
+];
+
+const paymentProviders = [
+  "BCA",
+  "Mandiri",
+  "BRI",
+  "BNI",
+  "Visa",
+  "Mastercard",
+  "Gopay",
+  "Dana",
+  "AkayPay",
+  "Kredivo",
+];
+
+const shippingProviders = [
+  "JNE",
+  "J&T Express",
+  "SiCepat",
+  "Ninja Xpress",
+  "Pos Indonesia",
+  "Anteraja",
+  "Wahana",
+  "GrabExpress",
+  "Gojek",
+];
+
+const securityBadges = ["PCI DSS", "ISO 27001", "Verisign"];
+
+const socialLinks = [
+  { label: "Facebook", href: "https://facebook.com", icon: "📘" },
+  { label: "Instagram", href: "https://instagram.com", icon: "📸" },
+  { label: "Twitter", href: "https://twitter.com", icon: "🐦" },
+  { label: "LinkedIn", href: "https://linkedin.com", icon: "💼" },
+  { label: "YouTube", href: "https://youtube.com", icon: "▶️" },
+];
+
+const downloadButtons = [
+  {
+    label: "App Store",
+    href: "https://apps.apple.com",
+    image: "https://placehold.co/120x36?text=App+Store",
+  },
+  {
+    label: "Google Play",
+    href: "https://play.google.com",
+    image: "https://placehold.co/120x36?text=Google+Play",
+  },
+];
+
+export function SiteFooter() {
+  const year = new Date().getFullYear();
+  const bankName = process.env.BANK_NAME ?? "Bank Contoh";
+  const accountName = process.env.ACCOUNT_NAME ?? "Nama Rekening";
+  const bankAccount = process.env.BANK_ACCOUNT ?? "0000000000";
+
+  return (
+    <footer className="mt-16 border-t border-gray-200 bg-white text-sm text-gray-600">
+      <div className="mx-auto max-w-6xl px-4 py-12">
+        <div className="grid gap-10 md:grid-cols-5">
+          <div>
+            <h2 className="text-base font-semibold text-gray-800">Layanan Pelanggan</h2>
+            <ul className="mt-4 space-y-2">
+              {customerServiceLinks.map((item) => (
+                <li key={item.label}>
+                  <Link href={item.href} className="transition hover:text-indigo-600">
+                    {item.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div>
+            <h2 className="text-base font-semibold text-gray-800">Jelajahi Akay Nusantara</h2>
+            <ul className="mt-4 space-y-2">
+              {exploreLinks.map((item) => (
+                <li key={item.label}>
+                  <Link href={item.href} className="transition hover:text-indigo-600">
+                    {item.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="space-y-6">
+            <div>
+              <h2 className="text-base font-semibold text-gray-800">Pembayaran</h2>
+              <div className="mt-4 grid grid-cols-3 gap-2 text-xs">
+                {paymentProviders.map((provider) => (
+                  <span key={provider} className="rounded border border-gray-200 bg-gray-50 px-2 py-1 text-center font-medium">
+                    {provider}
+                  </span>
+                ))}
+              </div>
+            </div>
+            <div>
+              <h2 className="text-base font-semibold text-gray-800">Pengiriman</h2>
+              <div className="mt-4 grid grid-cols-3 gap-2 text-xs">
+                {shippingProviders.map((provider) => (
+                  <span key={provider} className="rounded border border-gray-200 bg-gray-50 px-2 py-1 text-center font-medium">
+                    {provider}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-6">
+            <div>
+              <h2 className="text-base font-semibold text-gray-800">Ikuti Kami</h2>
+              <ul className="mt-4 space-y-2">
+                {socialLinks.map((item) => (
+                  <li key={item.label}>
+                    <Link href={item.href} className="flex items-center gap-2 transition hover:text-indigo-600">
+                      <span>{item.icon}</span>
+                      <span>{item.label}</span>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <h2 className="text-base font-semibold text-gray-800">Keamanan</h2>
+              <div className="mt-4 flex flex-wrap gap-2 text-xs">
+                {securityBadges.map((badge) => (
+                  <span key={badge} className="rounded border border-gray-200 bg-gray-50 px-3 py-1 font-medium">
+                    {badge}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            <h2 className="text-base font-semibold text-gray-800">Download Aplikasi</h2>
+            <img
+              src="https://placehold.co/120x120?text=QR"
+              alt="QR Code Download"
+              className="h-28 w-28 rounded border border-gray-200 object-contain"
+            />
+            <div className="space-y-3">
+              {downloadButtons.map((item) => (
+                <Link key={item.label} href={item.href} className="block">
+                  <img src={item.image} alt={item.label} className="w-36" />
+                </Link>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="border-t border-gray-200 bg-gray-50">
+        <div className="mx-auto flex max-w-6xl flex-col gap-2 px-4 py-4 text-center text-xs text-gray-500 md:flex-row md:items-center md:justify-between">
+          <div>
+            Transfer ke: <strong>{bankName} - {accountName}</strong> | No. Rek: <strong>{bankAccount}</strong>
+          </div>
+          <div>© {year} Akay Nusantara. Semua hak dilindungi.</div>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/lib/categories.ts
+++ b/lib/categories.ts
@@ -1,0 +1,21 @@
+export type ProductCategory = {
+  slug: string;
+  name: string;
+  description: string;
+  emoji: string;
+};
+
+export const productCategories: ProductCategory[] = [
+  { slug: "elektronik", name: "Elektronik", description: "Gadget & aksesoris", emoji: "🔌" },
+  { slug: "fashion", name: "Fashion", description: "Gaya terkini", emoji: "👗" },
+  { slug: "rumah-tangga", name: "Rumah Tangga", description: "Peralatan rumah", emoji: "🏠" },
+  { slug: "kecantikan", name: "Kecantikan", description: "Perawatan diri", emoji: "💄" },
+  { slug: "olahraga", name: "Olahraga", description: "Perlengkapan sport", emoji: "🏃" },
+  { slug: "hobi", name: "Hobi", description: "Koleksi & hobi", emoji: "🎨" },
+  { slug: "otomotif", name: "Otomotif", description: "Aksesoris kendaraan", emoji: "🚗" },
+  { slug: "makanan", name: "Makanan & Minuman", description: "Kuliner Nusantara", emoji: "🍜" }
+];
+
+export function getCategoryInfo(slug: string) {
+  return productCategories.find((category) => category.slug === slug);
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,6 +39,8 @@ model Product {
   title        String
   description  String?
   price        Int
+  originalPrice Int?
+  category     String     @default("umum")
   stock        Int        @default(0)
   imageUrl     String?
   isActive     Boolean    @default(true)


### PR DESCRIPTION
## Summary
- replace the manual redirect in the login API with `NextResponse.redirect`
- ensure the session cookies from the iron-session response are preserved when redirecting
- add a promotional banner slider and category menu to the homepage
- store a category and optional original price for each product, surfacing them in seller tools and customer-facing listings
- introduce a multi-column marketing footer on the homepage layout inspired by the provided reference
- guard strike-through pricing displays against null original prices on the homepage, storefront, and product detail views

## Testing
- npm run build *(fails: DATABASE_URL environment variable not configured in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e094cfe5d08320b92ad1c0ab1e7aae