### PR TITLE
Handle variant options payload when creating products

### DIFF
--- a/app/api/seller/products/create/route.ts
+++ b/app/api/seller/products/create/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
 import { getIronSession } from "iron-session";
 import { sessionOptions, SessionUser } from "@/lib/session";
 
@@ -11,7 +12,38 @@ export async function POST(req: NextRequest) {
   const imageUrl = String(form.get('imageUrl') || '');
   const description = String(form.get('description') || '');
   const warehouseId = String(form.get('warehouseId') || '');
+  const variantGroupsEntry = form.get('variantGroups');
 
+  let variantPayload: Prisma.InputJsonValue | undefined;
+
+  if (typeof variantGroupsEntry === 'string' && variantGroupsEntry.trim()) {
+    try {
+      const parsed = JSON.parse(variantGroupsEntry) as unknown;
+
+      if (Array.isArray(parsed) && parsed.length > 0) {
+        variantPayload = parsed.map((group) => {
+          if (group && typeof group === 'object') {
+            const plainGroup = { ...(group as Record<string, unknown>) };
+            const options = (plainGroup as { options?: unknown }).options;
+
+            if (Array.isArray(options)) {
+              plainGroup["options"] = options.map((option) =>
+                option && typeof option === 'object'
+                  ? { ...(option as Record<string, unknown>) }
+                  : option
+              );
+            }
+
+            return plainGroup;
+          }
+
+          return group;
+        }) as Prisma.InputJsonValue;
+      }
+    } catch (error) {
+      console.error('Failed to parse variant groups', error);
+    }
+  }
 
   const res = new NextResponse(null);
 
@@ -19,6 +51,17 @@ export async function POST(req: NextRequest) {
   const user = session.user as SessionUser | undefined;
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
-  await prisma.product.create({ data: { sellerId: user.id, title, price, stock, imageUrl, description, warehouseId: warehouseId || null } });
+  await prisma.product.create({
+    data: {
+      sellerId: user.id,
+      title,
+      price,
+      stock,
+      imageUrl,
+      description,
+      warehouseId: warehouseId || null,
+      variantOptions: variantPayload || undefined,
+    },
+  });
   return NextResponse.redirect(new URL('/seller/products', req.url));
 }


### PR DESCRIPTION
## Summary
- import the Prisma namespace in the seller product creation route
- parse the variant group form payload into plain JSON structures
- pass the normalized variant data to the product `variantOptions` field when present

## Testing
- npm run build *(fails: missing `DATABASE_URL` environment variable for Prisma migrations)*

------
https://chatgpt.com/codex/tasks/task_e_68e13fcbaab08320a34e7e9665e3abab