### PR TITLE
feat: streamline seller item status updates

### DIFF
--- a/app/seller/orders/page.tsx
+++ b/app/seller/orders/page.tsx
@@ -17,7 +17,7 @@ export default async function SellerOrders() {
       <h1 className="text-2xl font-semibold mb-4">Pesanan (Produk Saya)</h1>
       <div className="bg-white border rounded p-4">
         <table className="w-full text-sm">
-          <thead><tr className="text-left border-b"><th className="py-2">Tanggal</th><th>Kode</th><th>Status</th><th>Metode</th><th>Subtotal Saya</th><th>Aksi</th></tr></thead>
+          <thead><tr className="text-left border-b"><th className="py-2">Tanggal</th><th>Kode</th><th>Status</th><th>Metode</th><th>Subtotal Saya</th><th>Item</th><th>Aksi</th></tr></thead>
           <tbody>
             {orders.map(o => {
               const subtotal = o.items.reduce((s, it) => s + it.qty*it.price, 0);
@@ -28,27 +28,38 @@ export default async function SellerOrders() {
                   <td><span className={`badge ${o.status === 'PAID' ? 'badge-paid':'badge-pending'}`}>{o.status}</span></td>
                   <td>{o.paymentMethod}</td>
                   <td>Rp {new Intl.NumberFormat('id-ID').format(subtotal)}</td>
-                  <td><a className="link" href={`/order/${o.orderCode}`} target="_blank">Detail</a></td>
+                  <td className="py-2 align-top">
+                    <div className="space-y-3">
+                      {o.items.map(item => (
+                        <div key={item.id} className="border rounded px-3 py-2 bg-gray-50">
+                          <div className="flex justify-between gap-3">
+                            <div>
+                              <div className="font-medium">{item.product.title}</div>
+                              <div className="text-xs text-gray-500">Qty: {item.qty} • Rp {new Intl.NumberFormat('id-ID').format(item.price)}</div>
+                            </div>
+                            <span className={`badge ${item.status === 'PENDING' ? 'badge-pending' : 'badge-paid'}`}>{item.status}</span>
+                          </div>
+                          <form method="POST" action="/api/seller/item-status" className="mt-3 flex flex-col md:flex-row md:items-center gap-2">
+                            <input type="hidden" name="orderCode" value={o.orderCode} />
+                            <input type="hidden" name="orderItemId" value={item.id} />
+                            <select name="status" defaultValue={item.status} className="border rounded px-3 py-2 text-sm">
+                              <option value="PENDING">PENDING</option>
+                              <option value="PACKED">PACKED</option>
+                              <option value="SHIPPED">SHIPPED</option>
+                              <option value="DELIVERED">DELIVERED</option>
+                            </select>
+                            <button className="btn-primary text-sm">Update</button>
+                          </form>
+                        </div>
+                      ))}
+                    </div>
+                  </td>
+                  <td className="py-2 align-top"><a className="link" href={`/order/${o.orderCode}`} target="_blank">Detail</a></td>
                 </tr>
               );
             })}
           </tbody>
         </table>
-      </div>
-      <div className="mt-6 bg-white border rounded p-4">
-        <h2 className="font-semibold mb-2">Update Status Item</h2>
-        <form method="POST" action="/api/seller/item-status" className="grid grid-cols-1 md:grid-cols-4 gap-3">
-          <input name="orderCode" required placeholder="Kode Pesanan (ORD-...)" className="border rounded px-3 py-2"/>
-          <input name="orderItemId" required placeholder="OrderItem ID" className="border rounded px-3 py-2"/>
-          <select name="status" className="border rounded px-3 py-2">
-            <option value="PENDING">PENDING</option>
-            <option value="PACKED">PACKED</option>
-            <option value="SHIPPED">SHIPPED</option>
-            <option value="DELIVERED">DELIVERED</option>
-          </select>
-          <button className="btn-primary">Update</button>
-        </form>
-        <p className="text-xs text-gray-500 mt-2">* Dapatkan OrderItem ID di JSON order: /api/orders/ORD-XXXX</p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- embed item-level status controls directly within the seller orders table
- auto-fill order code and item id so sellers can update item status without manual lookup

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2cb8ef6ec832094e0aedfa2faae17