### PR TITLE
feat: add seller account profile workflow with admin approvals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 
 # Prisma
 prisma/migrations/
+tsconfig.tsbuildinfo

--- a/app/admin/banners/page.tsx
+++ b/app/admin/banners/page.tsx
@@ -1,0 +1,222 @@
+import Link from "next/link";
+
+import { prisma } from "@/lib/prisma";
+import { getSession } from "@/lib/session";
+
+export default async function AdminBannersPage({
+  searchParams,
+}: {
+  searchParams?: Record<string, string | string[] | undefined>;
+}) {
+  const session = await getSession();
+  const currentUser = session.user;
+
+  if (!currentUser || !currentUser.isAdmin) {
+    return <div>Admin only.</div>;
+  }
+
+  const banners = await prisma.promoBanner.findMany({
+    orderBy: [
+      { sortOrder: "asc" },
+      { createdAt: "asc" },
+    ],
+  });
+
+  const successMessage =
+    typeof searchParams?.message === "string" ? searchParams.message : undefined;
+  const errorMessage =
+    typeof searchParams?.error === "string" ? searchParams.error : undefined;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h1 className="text-2xl font-semibold">Admin: Kelola Banner Promo</h1>
+        <div className="flex flex-wrap gap-3 text-sm">
+          <Link className="link" href="/admin/users">
+            Manajemen Pengguna
+          </Link>
+          <Link className="link" href="/admin/products">
+            Kelola Produk
+          </Link>
+        </div>
+      </div>
+
+      {successMessage ? (
+        <div className="rounded border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700">
+          {successMessage}
+        </div>
+      ) : null}
+      {errorMessage ? (
+        <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+          {errorMessage}
+        </div>
+      ) : null}
+
+      <section className="rounded border bg-white p-4">
+        <h2 className="text-lg font-semibold">Tambah Banner Baru</h2>
+        <p className="mt-1 text-sm text-gray-500">
+          Lengkapi data di bawah untuk menambahkan slide promo baru pada beranda publik.
+        </p>
+        <form className="mt-4 grid gap-4 md:grid-cols-2" method="POST" action="/api/admin/banners/create">
+          <label className="flex flex-col text-sm">
+            <span className="font-medium">Judul</span>
+            <input className="rounded border px-3 py-2" name="title" placeholder="Contoh: Promo Spesial" required />
+          </label>
+          <label className="flex flex-col text-sm">
+            <span className="font-medium">Highlight</span>
+            <input className="rounded border px-3 py-2" name="highlight" placeholder="Contoh: Diskon 50%" required />
+          </label>
+          <label className="flex flex-col text-sm md:col-span-2">
+            <span className="font-medium">Deskripsi</span>
+            <textarea
+              className="rounded border px-3 py-2"
+              name="description"
+              placeholder="Detail singkat promonya"
+              rows={3}
+              required
+            />
+          </label>
+          <label className="flex flex-col text-sm">
+            <span className="font-medium">URL Gambar</span>
+            <input
+              className="rounded border px-3 py-2"
+              name="imageUrl"
+              placeholder="https://..."
+              type="url"
+              required
+            />
+          </label>
+          <label className="flex flex-col text-sm">
+            <span className="font-medium">Label Tombol</span>
+            <input className="rounded border px-3 py-2" name="ctaLabel" placeholder="Contoh: Belanja" required />
+          </label>
+          <label className="flex flex-col text-sm">
+            <span className="font-medium">Tujuan Tombol</span>
+            <input
+              className="rounded border px-3 py-2"
+              name="ctaHref"
+              placeholder="/product atau https://..."
+              required
+            />
+          </label>
+          <label className="flex flex-col text-sm">
+            <span className="font-medium">Urutan</span>
+            <input className="rounded border px-3 py-2" name="sortOrder" type="number" defaultValue={banners.length} />
+          </label>
+          <label className="flex items-center gap-2 text-sm">
+            <input className="h-4 w-4" type="checkbox" name="isActive" defaultChecked />
+            <span>Aktifkan banner ini</span>
+          </label>
+          <div className="md:col-span-2">
+            <button className="btn-outline" type="submit">
+              Simpan Banner
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold">Daftar Banner</h2>
+        {banners.length === 0 ? (
+          <div className="rounded border border-dashed border-gray-300 bg-white p-8 text-center text-sm text-gray-500">
+            Belum ada banner yang tersimpan.
+          </div>
+        ) : null}
+        <div className="grid gap-4">
+          {banners.map((banner) => (
+            <div key={banner.id} className="rounded border bg-white p-4 shadow-sm">
+              <div className="flex flex-col gap-4 md:flex-row">
+                <div className="md:w-1/3">
+                  <div className="aspect-[3/2] overflow-hidden rounded-lg border bg-gray-100">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={banner.imageUrl}
+                      alt={banner.title}
+                      className="h-full w-full object-cover"
+                    />
+                  </div>
+                </div>
+                <div className="flex-1 space-y-4">
+                  <form
+                    className="grid gap-4 md:grid-cols-2"
+                    method="POST"
+                    action={`/api/admin/banners/${banner.id}/update`}
+                  >
+                    <label className="flex flex-col text-sm">
+                      <span className="font-medium">Judul</span>
+                      <input className="rounded border px-3 py-2" name="title" defaultValue={banner.title} required />
+                    </label>
+                    <label className="flex flex-col text-sm">
+                      <span className="font-medium">Highlight</span>
+                      <input className="rounded border px-3 py-2" name="highlight" defaultValue={banner.highlight} required />
+                    </label>
+                    <label className="flex flex-col text-sm md:col-span-2">
+                      <span className="font-medium">Deskripsi</span>
+                      <textarea
+                        className="rounded border px-3 py-2"
+                        name="description"
+                        rows={3}
+                        defaultValue={banner.description}
+                        required
+                      />
+                    </label>
+                    <label className="flex flex-col text-sm">
+                      <span className="font-medium">URL Gambar</span>
+                      <input className="rounded border px-3 py-2" name="imageUrl" defaultValue={banner.imageUrl} required />
+                    </label>
+                    <label className="flex flex-col text-sm">
+                      <span className="font-medium">Label Tombol</span>
+                      <input className="rounded border px-3 py-2" name="ctaLabel" defaultValue={banner.ctaLabel} required />
+                    </label>
+                    <label className="flex flex-col text-sm">
+                      <span className="font-medium">Tujuan Tombol</span>
+                      <input className="rounded border px-3 py-2" name="ctaHref" defaultValue={banner.ctaHref} required />
+                    </label>
+                    <label className="flex flex-col text-sm">
+                      <span className="font-medium">Urutan</span>
+                      <input
+                        className="rounded border px-3 py-2"
+                        name="sortOrder"
+                        type="number"
+                        defaultValue={banner.sortOrder}
+                      />
+                    </label>
+                    <label className="flex items-center gap-2 text-sm">
+                      <input className="h-4 w-4" type="checkbox" name="isActive" defaultChecked={banner.isActive} />
+                      <span>Tampilkan di beranda</span>
+                    </label>
+                    <div className="md:col-span-2 flex flex-wrap gap-3">
+                      <button className="btn-outline" type="submit">
+                        Perbarui Banner
+                      </button>
+                      <a className="text-xs text-gray-500" href={`#banner-${banner.id}`}>
+                        ID: {banner.id}
+                      </a>
+                    </div>
+                  </form>
+                  <form
+                    className="inline-block"
+                    method="POST"
+                    action={`/api/admin/banners/${banner.id}/delete`}
+                  >
+                    <button
+                      className="rounded bg-red-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-red-700"
+                      type="submit"
+                    >
+                      Hapus Banner
+                    </button>
+                  </form>
+                  <div id={`banner-${banner.id}`} className="rounded border border-gray-200 bg-gray-50 p-3 text-xs text-gray-600">
+                    <div>Urutan: {banner.sortOrder}</div>
+                    <div>Diupdate: {banner.updatedAt.toLocaleString("id-ID")}</div>
+                    <div>Status: {banner.isActive ? "Aktif" : "Non-aktif"}</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/admin/products/page.tsx
+++ b/app/admin/products/page.tsx
@@ -1,0 +1,208 @@
+import Link from "next/link";
+
+import { prisma } from "@/lib/prisma";
+import { getSession } from "@/lib/session";
+
+export default async function AdminProductsPage({
+  searchParams,
+}: {
+  searchParams?: Record<string, string | string[] | undefined>;
+}) {
+  const session = await getSession();
+  const currentUser = session.user;
+  if (!currentUser || !currentUser.isAdmin) {
+    return <div>Admin only.</div>;
+  }
+
+  const sellerIdFilter =
+    typeof searchParams?.sellerId === "string" ? searchParams?.sellerId : undefined;
+
+  const products = await prisma.product.findMany({
+    where: sellerIdFilter ? { sellerId: sellerIdFilter } : undefined,
+    orderBy: { createdAt: "desc" },
+    include: {
+      seller: {
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          slug: true,
+        },
+      },
+      warehouse: {
+        select: {
+          name: true,
+        },
+      },
+    },
+  });
+
+  const successMessage =
+    typeof searchParams?.message === "string" ? searchParams.message : undefined;
+  const errorMessage = typeof searchParams?.error === "string" ? searchParams.error : undefined;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-4">
+        <h1 className="text-2xl font-semibold">Admin: Kelola Produk Seller</h1>
+        <div className="flex items-center gap-3 text-sm">
+          <Link className="link" href="/admin/banners">
+            Kelola Banner Promo
+          </Link>
+          <Link className="link" href="/admin/users">
+            &larr; Kembali ke pengguna
+          </Link>
+        </div>
+      </div>
+      <form className="flex flex-wrap items-end gap-2" method="GET">
+        <label className="flex flex-col text-sm">
+          <span className="font-medium">Filter Seller ID</span>
+          <input
+            className="rounded border px-2 py-1"
+            name="sellerId"
+            placeholder="Masukkan ID seller"
+            defaultValue={sellerIdFilter ?? ""}
+          />
+        </label>
+        <button className="btn-outline" type="submit">
+          Terapkan
+        </button>
+        {sellerIdFilter ? (
+          <Link className="link text-sm" href="/admin/products">
+            Reset filter
+          </Link>
+        ) : null}
+      </form>
+      {successMessage ? (
+        <div className="rounded border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700">
+          {successMessage}
+        </div>
+      ) : null}
+      {errorMessage ? (
+        <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+          {errorMessage}
+        </div>
+      ) : null}
+      <div className="overflow-x-auto rounded border bg-white">
+        <table className="min-w-[960px] w-full text-sm">
+          <thead>
+            <tr className="border-b text-left">
+              <th className="py-2">Produk</th>
+              <th>Seller</th>
+              <th>Harga</th>
+              <th>Stok</th>
+              <th>Status</th>
+              <th>Aksi</th>
+            </tr>
+          </thead>
+          <tbody>
+            {products.map((product) => (
+              <tr key={product.id} className="border-b align-top">
+                <td className="py-3">
+                  <div className="font-medium">{product.title}</div>
+                  <div className="text-xs text-gray-500">Kategori: {product.category}</div>
+                  {product.warehouse ? (
+                    <div className="text-xs text-gray-500">
+                      Gudang: {product.warehouse.name}
+                    </div>
+                  ) : null}
+                  <div className="text-xs text-gray-400">ID: {product.id}</div>
+                </td>
+                <td className="py-3 text-xs">
+                  <div className="font-medium text-sm">{product.seller?.name}</div>
+                  <div>{product.seller?.email}</div>
+                  <div>Slug: {product.seller?.slug}</div>
+                  <Link className="link" href={`/admin/users#user-${product.sellerId}`}>
+                    Lihat seller
+                  </Link>
+                </td>
+                <td className="py-3">Rp {product.price.toLocaleString("id-ID")}</td>
+                <td className="py-3">{product.stock}</td>
+                <td className="py-3">
+                  <span className={`badge ${product.isActive ? "badge-paid" : "badge-pending"}`}>
+                    {product.isActive ? "Aktif" : "Non-aktif"}
+                  </span>
+                </td>
+                <td className="py-3">
+                  <form
+                    method="POST"
+                    action={`/api/admin/products/${product.id}/update`}
+                    className="space-y-2"
+                  >
+                    <input type="hidden" name="sellerId" value={sellerIdFilter ?? ""} />
+                    <label className="flex flex-col gap-1 text-xs">
+                      <span>Nama Produk</span>
+                      <input
+                        className="rounded border px-2 py-1"
+                        name="title"
+                        defaultValue={product.title}
+                        required
+                      />
+                    </label>
+                    <label className="flex flex-col gap-1 text-xs">
+                      <span>Harga (IDR)</span>
+                      <input
+                        className="rounded border px-2 py-1"
+                        type="number"
+                        name="price"
+                        min="0"
+                        defaultValue={product.price}
+                        required
+                      />
+                    </label>
+                    <label className="flex flex-col gap-1 text-xs">
+                      <span>Stok</span>
+                      <input
+                        className="rounded border px-2 py-1"
+                        type="number"
+                        name="stock"
+                        min="0"
+                        defaultValue={product.stock}
+                        required
+                      />
+                    </label>
+                    <label className="flex items-center gap-2 text-xs">
+                      <input
+                        type="checkbox"
+                        name="isActive"
+                        defaultChecked={product.isActive}
+                      />
+                      <span>Produk aktif</span>
+                    </label>
+                    <label className="flex flex-col gap-1 text-xs">
+                      <span>Kategori</span>
+                      <input
+                        className="rounded border px-2 py-1"
+                        name="category"
+                        defaultValue={product.category}
+                        required
+                      />
+                    </label>
+                    <label className="flex flex-col gap-1 text-xs">
+                      <span>Deskripsi</span>
+                      <textarea
+                        className="min-h-[80px] rounded border px-2 py-1"
+                        name="description"
+                        defaultValue={product.description ?? ""}
+                      />
+                    </label>
+                    <button className="btn-primary w-full text-xs" type="submit">
+                      Simpan perubahan
+                    </button>
+                  </form>
+                </td>
+              </tr>
+            ))}
+            {products.length === 0 ? (
+              <tr>
+                <td className="py-4 text-center text-sm text-gray-500" colSpan={6}>
+                  Tidak ada produk yang ditemukan.
+                </td>
+              </tr>
+            ) : null}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -1,0 +1,494 @@
+import Link from "next/link";
+
+import { ProfileChangeField } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { getSession } from "@/lib/session";
+
+const storeBadges = ["BASIC", "STAR", "STAR_PLUS", "MALL", "PREMIUM"] as const;
+
+export default async function AdminUsersPage({
+  searchParams,
+}: {
+  searchParams?: Record<string, string | string[] | undefined>;
+}) {
+  const session = await getSession();
+  const currentUser = session.user;
+  if (!currentUser || !currentUser.isAdmin) {
+    return <div>Admin only.</div>;
+  }
+
+  const [users, pendingRequests] = await Promise.all([
+    prisma.user.findMany({
+      orderBy: { createdAt: "desc" },
+      include: {
+        _count: {
+          select: {
+            products: true,
+            orderItems: true,
+          },
+        },
+        warehouses: {
+          select: {
+            id: true,
+          },
+        },
+        profileChangeRequests: {
+          where: { status: "PENDING" },
+          orderBy: { createdAt: "asc" },
+        },
+      },
+    }),
+    prisma.profileChangeRequest.findMany({
+      where: { status: "PENDING" },
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+            storeName: true,
+            email: true,
+          },
+        },
+      },
+      orderBy: { createdAt: "asc" },
+    }),
+  ]);
+
+  const successMessage =
+    typeof searchParams?.message === "string" ? searchParams.message : undefined;
+  const errorMessage =
+    typeof searchParams?.error === "string" ? searchParams.error : undefined;
+
+  function getRequestLabel(field: ProfileChangeField) {
+    switch (field) {
+      case ProfileChangeField.STORE_NAME:
+        return "Nama Toko";
+      case ProfileChangeField.EMAIL:
+        return "Email";
+      default:
+        return field;
+    }
+  }
+
+  return (
+    <div>
+      <h1 className="text-2xl font-semibold mb-4">Admin: Manajemen Pengguna &amp; Seller</h1>
+      <div className="mb-4 flex flex-wrap gap-3 text-sm">
+        <Link className="link" href="/admin/products">
+          Kelola Produk Seller
+        </Link>
+        <Link className="link" href="/admin/banners">
+          Kelola Banner Promo
+        </Link>
+        <Link className="link" href="/admin/orders">
+          Pantau Pesanan
+        </Link>
+      </div>
+      {successMessage ? (
+        <div className="mb-4 rounded border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700">
+          {successMessage}
+        </div>
+      ) : null}
+      {errorMessage ? (
+        <div className="mb-4 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+          {errorMessage}
+        </div>
+      ) : null}
+      <div className="bg-white border rounded p-4 overflow-x-auto">
+        <table className="w-full text-sm min-w-[720px]">
+          <thead>
+            <tr className="text-left border-b">
+              <th className="py-2">Nama</th>
+              <th>Email</th>
+              <th>Peran</th>
+              <th>Toko</th>
+              <th>Produk</th>
+              <th>Penjualan</th>
+              <th>Aksi</th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map((user) => {
+              const isCurrent = user.id === currentUser.id;
+              const hasWarehouse = user.warehouses.length > 0;
+              const isSeller = user._count.products > 0 || hasWarehouse;
+              const storeDisplayName = user.storeName?.trim().length ? user.storeName : user.name;
+              const pendingStoreName = user.profileChangeRequests.find(
+                (request) => request.field === ProfileChangeField.STORE_NAME,
+              );
+              const pendingEmail = user.profileChangeRequests.find(
+                (request) => request.field === ProfileChangeField.EMAIL,
+              );
+              return (
+                <tr key={user.id} id={`user-${user.id}`} className="border-b align-top">
+                  <td className="py-3">
+                    <div className="flex items-start gap-3">
+                      <div className="h-12 w-12 overflow-hidden rounded-full bg-gray-200">
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img
+                          src={
+                            user.avatarUrl?.trim()
+                              ? user.avatarUrl
+                              : "https://placehold.co/96x96?text=Foto"
+                          }
+                          alt={user.name ?? "Foto profil"}
+                          className="h-full w-full object-cover"
+                        />
+                      </div>
+                      <div>
+                        <div className="font-medium">{user.name}</div>
+                        <div className="text-xs text-gray-600">Nama Toko: {storeDisplayName}</div>
+                        <div className="text-xs text-gray-500">
+                          Bergabung {new Date(user.createdAt).toLocaleDateString("id-ID")}
+                        </div>
+                        {pendingStoreName ? (
+                          <div className="mt-1 inline-flex items-center rounded bg-amber-100 px-2 py-0.5 text-[11px] font-medium text-amber-700">
+                            Permintaan nama toko baru: {pendingStoreName.newValue}
+                          </div>
+                        ) : null}
+                      </div>
+                    </div>
+                  </td>
+                  <td className="py-3">
+                    <div>{user.email}</div>
+                    {pendingEmail ? (
+                      <div className="mt-1 inline-flex items-center rounded bg-amber-100 px-2 py-0.5 text-[11px] font-medium text-amber-700">
+                        Permintaan email baru: {pendingEmail.newValue}
+                      </div>
+                    ) : null}
+                  </td>
+                  <td className="py-3">
+                    <span className={`badge ${user.isAdmin ? "badge-paid" : "badge-pending"}`}>
+                      {user.isAdmin ? "ADMIN" : "USER"}
+                    </span>
+                  </td>
+                  <td className="py-3">
+                    {isSeller ? (
+                      <div className="space-y-1">
+                        <div className="text-xs uppercase tracking-wide text-gray-500">Badge</div>
+                        <form
+                          method="POST"
+                          action={`/api/admin/users/${user.id}/store-badge`}
+                          className="flex flex-col sm:flex-row sm:items-center gap-2"
+                        >
+                          <select
+                            name="badge"
+                            defaultValue={user.storeBadge}
+                            className="border rounded px-2 py-1 text-xs"
+                          >
+                            {storeBadges.map((badge) => (
+                              <option key={badge} value={badge}>
+                                {badge}
+                              </option>
+                            ))}
+                          </select>
+                          <button className="btn-outline text-xs px-3 py-1">Simpan</button>
+                        </form>
+                        <div className="flex items-center gap-2 text-xs">
+                          <span className={`badge ${user.storeIsOnline ? "badge-paid" : "badge-pending"}`}>
+                            {user.storeIsOnline ? "Toko Aktif" : "Toko Tutup"}
+                          </span>
+                          <form
+                            method="POST"
+                            action={`/api/admin/users/${user.id}/toggle-store`}
+                          >
+                            <button className="link text-xs" type="submit">
+                              {user.storeIsOnline ? "Tutup" : "Buka"}
+                            </button>
+                          </form>
+                        </div>
+                        <form
+                          method="POST"
+                          action={`/api/admin/users/${user.id}/delete-store`}
+                          className="pt-1"
+                        >
+                          <button
+                            className="text-xs rounded bg-red-600 px-3 py-1 font-medium text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:bg-red-300"
+                            type="submit"
+                            disabled={user._count.orderItems > 0}
+                            title={
+                              user._count.orderItems > 0
+                                ? "Tidak dapat menghapus toko karena memiliki riwayat penjualan"
+                                : undefined
+                            }
+                          >
+                            Hapus Toko
+                          </button>
+                        </form>
+                      </div>
+                    ) : (
+                      <div className="text-xs text-gray-500">Belum memiliki produk</div>
+                    )}
+                  </td>
+                  <td className="py-3">{user._count.products}</td>
+                  <td className="py-3">{user._count.orderItems}</td>
+                  <td className="py-3 space-y-3">
+                    <form
+                      method="POST"
+                      action={`/api/admin/users/${user.id}/toggle-admin`}
+                      className="inline"
+                    >
+                      <button
+                        className="btn-primary text-xs"
+                        type="submit"
+                        disabled={isCurrent}
+                        title={isCurrent ? "Tidak dapat mengubah status admin sendiri" : undefined}
+                      >
+                        {user.isAdmin ? "Cabut Admin" : "Jadikan Admin"}
+                      </button>
+                    </form>
+                    {isSeller ? (
+                      <Link
+                        className="link block text-xs"
+                        href={`/admin/products?sellerId=${user.id}`}
+                      >
+                        Kelola produk seller
+                      </Link>
+                    ) : null}
+                    <details className="rounded border bg-gray-50 p-2 text-xs">
+                      <summary className="cursor-pointer font-semibold">
+                        Edit data seller
+                      </summary>
+                      <form
+                        method="POST"
+                        action={`/api/admin/users/${user.id}/update-profile`}
+                        className="mt-2 space-y-2"
+                      >
+                        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                          <label className="flex flex-col gap-1">
+                            <span>Nama</span>
+                            <input
+                              className="rounded border px-2 py-1"
+                              name="name"
+                              defaultValue={user.name ?? ""}
+                              required
+                            />
+                          </label>
+                          <label className="flex flex-col gap-1">
+                            <span>Nama Toko</span>
+                            <input
+                              className="rounded border px-2 py-1"
+                              name="storeName"
+                              defaultValue={storeDisplayName ?? ""}
+                              required
+                            />
+                          </label>
+                          <label className="flex flex-col gap-1">
+                            <span>Email</span>
+                            <input
+                              className="rounded border px-2 py-1"
+                              type="email"
+                              name="email"
+                              defaultValue={user.email ?? ""}
+                              required
+                            />
+                          </label>
+                          <label className="flex flex-col gap-1">
+                            <span>Slug</span>
+                            <input
+                              className="rounded border px-2 py-1"
+                              name="slug"
+                              defaultValue={user.slug ?? ""}
+                              required
+                            />
+                          </label>
+                          <label className="flex flex-col gap-1">
+                            <span>Rating Toko</span>
+                            <input
+                              className="rounded border px-2 py-1"
+                              type="number"
+                              name="storeRating"
+                              step="0.1"
+                              min="0"
+                              max="5"
+                              defaultValue={user.storeRating ?? ""}
+                            />
+                          </label>
+                          <label className="flex flex-col gap-1">
+                            <span>Jumlah Penilaian</span>
+                            <input
+                              className="rounded border px-2 py-1"
+                              type="number"
+                              name="storeRatingCount"
+                              min="0"
+                              defaultValue={user.storeRatingCount}
+                            />
+                          </label>
+                          <label className="flex flex-col gap-1">
+                            <span>Followers</span>
+                            <input
+                              className="rounded border px-2 py-1"
+                              type="number"
+                              name="storeFollowers"
+                              min="0"
+                              defaultValue={user.storeFollowers}
+                            />
+                          </label>
+                          <label className="flex flex-col gap-1">
+                            <span>Following</span>
+                            <input
+                              className="rounded border px-2 py-1"
+                              type="number"
+                              name="storeFollowing"
+                              min="0"
+                              defaultValue={user.storeFollowing}
+                            />
+                          </label>
+                          <label className="flex flex-col gap-1 sm:col-span-2">
+                            <span>Foto Profil (URL)</span>
+                            <input
+                              className="rounded border px-2 py-1"
+                              type="url"
+                              name="avatarUrl"
+                              placeholder="https://contoh.com/avatar.jpg"
+                              defaultValue={user.avatarUrl ?? ""}
+                            />
+                            <span className="text-[11px] text-gray-500">
+                              Kosongkan untuk menghapus foto profil.
+                            </span>
+                          </label>
+                          <div className="sm:col-span-2">
+                            <span className="mb-1 block text-xs font-semibold uppercase text-gray-500">
+                              Pratinjau Foto Profil
+                            </span>
+                            <div className="flex items-center gap-3">
+                              <div className="h-16 w-16 overflow-hidden rounded-full bg-gray-200">
+                                {/* eslint-disable-next-line @next/next/no-img-element */}
+                                <img
+                                  src={
+                                    user.avatarUrl?.trim()
+                                      ? user.avatarUrl
+                                      : "https://placehold.co/128x128?text=Foto"
+                                  }
+                                  alt={`Foto ${user.name ?? "profil"}`}
+                                  className="h-full w-full object-cover"
+                                />
+                              </div>
+                              <span className="text-xs text-gray-500">
+                                Gunakan URL gambar langsung (https://).
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                        <label className="flex items-center gap-2">
+                          <input
+                            type="checkbox"
+                            name="storeIsOnline"
+                            defaultChecked={user.storeIsOnline}
+                          />
+                          <span>Toko aktif</span>
+                        </label>
+                        <label className="flex flex-col gap-1">
+                          <span>Badge</span>
+                          <select
+                            name="badge"
+                            defaultValue={user.storeBadge}
+                            className="rounded border px-2 py-1"
+                          >
+                            {storeBadges.map((badge) => (
+                              <option key={badge} value={badge}>
+                                {badge}
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                        <button className="btn-primary w-full" type="submit">
+                          Simpan Perubahan
+                        </button>
+                      </form>
+                    </details>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-8 rounded border border-gray-200 bg-white p-4">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-lg font-semibold">Permintaan Persetujuan Profil</h2>
+            <p className="text-sm text-gray-500">
+              Tinjau perubahan nama toko dan email yang diajukan seller sebelum disetujui.
+            </p>
+          </div>
+        </div>
+        {pendingRequests.length === 0 ? (
+          <div className="mt-4 rounded border border-dashed border-gray-200 bg-gray-50 p-6 text-sm text-gray-500">
+            Belum ada permintaan perubahan yang menunggu persetujuan.
+          </div>
+        ) : (
+          <div className="mt-4 overflow-x-auto">
+            <table className="w-full min-w-[720px] text-sm">
+              <thead>
+                <tr className="border-b text-left">
+                  <th className="py-2">Pengguna</th>
+                  <th>Perubahan</th>
+                  <th>Nilai Saat Ini</th>
+                  <th>Permintaan Baru</th>
+                  <th>Diajukan</th>
+                  <th>Aksi</th>
+                </tr>
+              </thead>
+              <tbody>
+                {pendingRequests.map((request) => {
+                  const fieldLabel = getRequestLabel(request.field);
+                  const currentValue =
+                    request.field === ProfileChangeField.STORE_NAME
+                      ? request.user.storeName?.trim().length
+                        ? request.user.storeName
+                        : request.user.name
+                      : request.user.email;
+                  return (
+                    <tr key={request.id} className="border-b align-top">
+                      <td className="py-3">
+                        <div className="font-medium">{request.user.name}</div>
+                        <div className="text-xs text-gray-500">ID: {request.user.id}</div>
+                      </td>
+                      <td className="py-3">{fieldLabel}</td>
+                      <td className="py-3">
+                        <span className="break-words text-gray-600">{currentValue}</span>
+                      </td>
+                      <td className="py-3">
+                        <span className="break-words font-semibold text-gray-900">{request.newValue}</span>
+                      </td>
+                      <td className="py-3 text-sm text-gray-500">
+                        {new Date(request.createdAt).toLocaleString("id-ID")}
+                      </td>
+                      <td className="py-3 space-y-2">
+                        <form
+                          method="POST"
+                          action={`/api/admin/profile-requests/${request.id}/approve`}
+                        >
+                          <button
+                            className="w-full rounded bg-emerald-500 px-3 py-1.5 text-sm font-semibold text-white hover:bg-emerald-600"
+                            type="submit"
+                          >
+                            Setujui
+                          </button>
+                        </form>
+                        <form
+                          method="POST"
+                          action={`/api/admin/profile-requests/${request.id}/reject`}
+                        >
+                          <button
+                            className="w-full rounded border border-red-500 px-3 py-1.5 text-sm font-semibold text-red-600 hover:bg-red-50"
+                            type="submit"
+                          >
+                            Tolak
+                          </button>
+                        </form>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/api/account/avatar/route.ts
+++ b/app/api/account/avatar/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getIronSession } from "iron-session";
+
+import { prisma } from "@/lib/prisma";
+import { sessionOptions, SessionUser } from "@/lib/session";
+
+const MAX_FILE_SIZE = 1_000_000; // 1 MB
+const ALLOWED_MIME = new Set(["image/jpeg", "image/png", "image/webp"]);
+
+export async function POST(req: NextRequest) {
+  const res = new NextResponse();
+  const session = await getIronSession<{ user?: SessionUser }>(req, res, sessionOptions);
+  const sessionUser = session.user;
+
+  if (!sessionUser) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const formData = await req.formData();
+  const file = formData.get("avatar");
+
+  if (!(file instanceof File)) {
+    const redirectUrl = new URL("/seller/dashboard", req.url);
+    redirectUrl.searchParams.set("error", "Harap pilih file gambar yang valid");
+    const redirectResponse = NextResponse.redirect(redirectUrl);
+    res.headers.forEach((value, key) => {
+      if (key.toLowerCase() === "set-cookie") {
+        redirectResponse.headers.append(key, value);
+      }
+    });
+    return redirectResponse;
+  }
+
+  if (!ALLOWED_MIME.has(file.type)) {
+    const redirectUrl = new URL("/seller/dashboard", req.url);
+    redirectUrl.searchParams.set("error", "Format gambar harus JPG, PNG, atau WEBP");
+    const redirectResponse = NextResponse.redirect(redirectUrl);
+    res.headers.forEach((value, key) => {
+      if (key.toLowerCase() === "set-cookie") {
+        redirectResponse.headers.append(key, value);
+      }
+    });
+    return redirectResponse;
+  }
+
+  const arrayBuffer = await file.arrayBuffer();
+  if (arrayBuffer.byteLength > MAX_FILE_SIZE) {
+    const redirectUrl = new URL("/seller/dashboard", req.url);
+    redirectUrl.searchParams.set("error", "Ukuran gambar melebihi 1 MB");
+    const redirectResponse = NextResponse.redirect(redirectUrl);
+    res.headers.forEach((value, key) => {
+      if (key.toLowerCase() === "set-cookie") {
+        redirectResponse.headers.append(key, value);
+      }
+    });
+    return redirectResponse;
+  }
+
+  const data = Buffer.from(arrayBuffer);
+
+  const avatarPath = `/api/users/${sessionUser.id}/avatar?ts=${Date.now()}`;
+
+  await prisma.$transaction([
+    prisma.userAvatar.upsert({
+      where: { userId: sessionUser.id },
+      create: {
+        userId: sessionUser.id,
+        mimeType: file.type,
+        data,
+      },
+      update: {
+        mimeType: file.type,
+        data,
+      },
+    }),
+    prisma.user.update({
+      where: { id: sessionUser.id },
+      data: { avatarUrl: avatarPath },
+    }),
+  ]);
+
+  const redirectUrl = new URL("/seller/dashboard", req.url);
+  redirectUrl.searchParams.set("message", "Foto profil berhasil diperbarui");
+  const redirectResponse = NextResponse.redirect(redirectUrl);
+  res.headers.forEach((value, key) => {
+    if (key.toLowerCase() === "set-cookie") {
+      redirectResponse.headers.append(key, value);
+    }
+  });
+  return redirectResponse;
+}

--- a/app/api/account/profile/route.ts
+++ b/app/api/account/profile/route.ts
@@ -1,0 +1,146 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ProfileChangeField, ProfileChangeStatus } from "@prisma/client";
+import { getIronSession } from "iron-session";
+
+import { prisma } from "@/lib/prisma";
+import { sessionOptions, SessionUser } from "@/lib/session";
+
+function normalizeEmail(value: FormDataEntryValue | null) {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return trimmed.toLowerCase();
+}
+
+function normalizeText(value: FormDataEntryValue | null) {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return trimmed;
+}
+
+export async function POST(req: NextRequest) {
+  const res = new NextResponse();
+  const session = await getIronSession<{ user?: SessionUser }>(req, res, sessionOptions);
+  const sessionUser = session.user;
+
+  if (!sessionUser) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const formData = await req.formData();
+
+  const name = normalizeText(formData.get("name"));
+  const storeName = normalizeText(formData.get("storeName"));
+  const email = normalizeEmail(formData.get("email"));
+
+  const buildRedirect = (message: string, type: "success" | "error") => {
+    const url = new URL("/seller/dashboard", req.url);
+    url.searchParams.set(type === "success" ? "message" : "error", message);
+    const redirectResponse = NextResponse.redirect(url);
+    res.headers.forEach((value, key) => {
+      if (key.toLowerCase() === "set-cookie") {
+        redirectResponse.headers.append(key, value);
+      }
+    });
+    return redirectResponse;
+  };
+
+  if (!name) {
+    return buildRedirect("Nama tidak boleh kosong", "error");
+  }
+  if (!storeName) {
+    return buildRedirect("Nama toko tidak boleh kosong", "error");
+  }
+  if (!email) {
+    return buildRedirect("Email tidak boleh kosong", "error");
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: sessionUser.id },
+    include: {
+      profileChangeRequests: {
+        where: { status: ProfileChangeStatus.PENDING },
+      },
+    },
+  });
+
+  if (!user) {
+    return buildRedirect("Akun tidak ditemukan", "error");
+  }
+
+  const actions: (() => Promise<void>)[] = [];
+
+  if (user.name !== name) {
+    actions.push(async () => {
+      await prisma.user.update({
+        where: { id: user.id },
+        data: { name },
+      });
+      session.user = { ...sessionUser, name };
+      await session.save();
+    });
+  }
+
+  const activeStoreName = user.storeName?.trim().length ? user.storeName : user.name;
+  if (storeName !== activeStoreName) {
+    const existing = user.profileChangeRequests.find(
+      (req) => req.field === ProfileChangeField.STORE_NAME,
+    );
+    actions.push(async () => {
+      if (existing) {
+        await prisma.profileChangeRequest.update({
+          where: { id: existing.id },
+          data: { newValue: storeName, createdAt: new Date() },
+        });
+      } else {
+        await prisma.profileChangeRequest.create({
+          data: {
+            userId: user.id,
+            field: ProfileChangeField.STORE_NAME,
+            newValue: storeName,
+          },
+        });
+      }
+    });
+  }
+
+  if (email !== user.email) {
+    const existing = user.profileChangeRequests.find((req) => req.field === ProfileChangeField.EMAIL);
+    actions.push(async () => {
+      const duplicate = await prisma.user.findUnique({ where: { email } });
+      if (duplicate && duplicate.id !== user.id) {
+        throw new Error("Email sudah digunakan pengguna lain");
+      }
+      if (existing) {
+        await prisma.profileChangeRequest.update({
+          where: { id: existing.id },
+          data: { newValue: email, createdAt: new Date() },
+        });
+      } else {
+        await prisma.profileChangeRequest.create({
+          data: {
+            userId: user.id,
+            field: ProfileChangeField.EMAIL,
+            newValue: email,
+          },
+        });
+      }
+    });
+  }
+
+  if (actions.length === 0) {
+    return buildRedirect("Tidak ada perubahan yang disimpan", "success");
+  }
+
+  try {
+    for (const action of actions) {
+      await action();
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Gagal menyimpan perubahan";
+    return buildRedirect(message, "error");
+  }
+
+  return buildRedirect("Perubahan profil berhasil diajukan", "success");
+}

--- a/app/api/admin/banners/[id]/delete/route.ts
+++ b/app/api/admin/banners/[id]/delete/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getIronSession } from "iron-session";
+
+import { prisma } from "@/lib/prisma";
+import { sessionOptions, SessionUser } from "@/lib/session";
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const res = new NextResponse();
+  const session = await getIronSession<{ user?: SessionUser }>(req, res, sessionOptions);
+  const actor = session.user;
+
+  if (!actor || !actor.isAdmin) {
+    return NextResponse.json({ error: "Admin only" }, { status: 403 });
+  }
+
+  const bannerId = Number(params.id);
+  if (!Number.isInteger(bannerId)) {
+    const redirectUrl = new URL("/admin/banners", req.url);
+    redirectUrl.searchParams.set("error", "Banner tidak ditemukan");
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  try {
+    await prisma.promoBanner.delete({ where: { id: bannerId } });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Gagal menghapus banner";
+    const redirectUrl = new URL("/admin/banners", req.url);
+    redirectUrl.searchParams.set("error", message);
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  const redirectUrl = new URL("/admin/banners", req.url);
+  redirectUrl.searchParams.set("message", "Banner berhasil dihapus");
+  return NextResponse.redirect(redirectUrl);
+}

--- a/app/api/admin/banners/[id]/update/route.ts
+++ b/app/api/admin/banners/[id]/update/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getIronSession } from "iron-session";
+
+import { prisma } from "@/lib/prisma";
+import { sessionOptions, SessionUser } from "@/lib/session";
+
+import { ensureUrl, ensureText, toNumber } from "../../utils";
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const res = new NextResponse();
+  const session = await getIronSession<{ user?: SessionUser }>(req, res, sessionOptions);
+  const actor = session.user;
+
+  if (!actor || !actor.isAdmin) {
+    return NextResponse.json({ error: "Admin only" }, { status: 403 });
+  }
+
+  const bannerId = Number(params.id);
+  if (!Number.isInteger(bannerId)) {
+    const redirectUrl = new URL("/admin/banners", req.url);
+    redirectUrl.searchParams.set("error", "Banner tidak ditemukan");
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  const formData = await req.formData();
+
+  let title: string;
+  let description: string;
+  let highlight: string;
+  let imageUrl: string;
+  let ctaLabel: string;
+  let ctaHref: string;
+  let sortOrder: number;
+  const isActive = formData.get("isActive") === "on";
+
+  try {
+    title = ensureText(formData.get("title"), "Judul");
+    description = ensureText(formData.get("description"), "Deskripsi");
+    highlight = ensureText(formData.get("highlight"), "Highlight");
+    imageUrl = ensureUrl(formData.get("imageUrl"));
+    ctaLabel = ensureText(formData.get("ctaLabel"), "Label tombol");
+    ctaHref = ensureUrl(formData.get("ctaHref"), { allowRelative: true });
+    sortOrder = toNumber(formData.get("sortOrder"), 0);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Input tidak valid";
+    const redirectUrl = new URL("/admin/banners", req.url);
+    redirectUrl.searchParams.set("error", message);
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  try {
+    await prisma.promoBanner.update({
+      where: { id: bannerId },
+      data: {
+        title,
+        description,
+        highlight,
+        imageUrl,
+        ctaLabel,
+        ctaHref,
+        sortOrder,
+        isActive,
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Gagal memperbarui banner";
+    const redirectUrl = new URL("/admin/banners", req.url);
+    redirectUrl.searchParams.set("error", message);
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  const redirectUrl = new URL("/admin/banners", req.url);
+  redirectUrl.searchParams.set("message", "Banner berhasil diperbarui");
+  return NextResponse.redirect(redirectUrl);
+}

--- a/app/api/admin/banners/create/route.ts
+++ b/app/api/admin/banners/create/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getIronSession } from "iron-session";
+
+import { prisma } from "@/lib/prisma";
+import { sessionOptions, SessionUser } from "@/lib/session";
+
+import { ensureText, ensureUrl, toNumber } from "../utils";
+
+export async function POST(req: NextRequest) {
+  const res = new NextResponse();
+  const session = await getIronSession<{ user?: SessionUser }>(req, res, sessionOptions);
+  const actor = session.user;
+
+  if (!actor || !actor.isAdmin) {
+    return NextResponse.json({ error: "Admin only" }, { status: 403 });
+  }
+
+  const formData = await req.formData();
+
+  let title: string;
+  let description: string;
+  let highlight: string;
+  let imageUrl: string;
+  let ctaLabel: string;
+  let ctaHref: string;
+  let sortOrder: number;
+  const isActive = formData.get("isActive") === "on";
+
+  try {
+    title = ensureText(formData.get("title"), "Judul");
+    description = ensureText(formData.get("description"), "Deskripsi");
+    highlight = ensureText(formData.get("highlight"), "Highlight");
+    imageUrl = ensureUrl(formData.get("imageUrl"));
+    ctaLabel = ensureText(formData.get("ctaLabel"), "Label tombol");
+    ctaHref = ensureUrl(formData.get("ctaHref"), { allowRelative: true });
+    sortOrder = toNumber(formData.get("sortOrder"), 0);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Input tidak valid";
+    const redirectUrl = new URL("/admin/banners", req.url);
+    redirectUrl.searchParams.set("error", message);
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  try {
+    await prisma.promoBanner.create({
+      data: {
+        title,
+        description,
+        highlight,
+        imageUrl,
+        ctaLabel,
+        ctaHref,
+        sortOrder,
+        isActive,
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Gagal menyimpan banner";
+    const redirectUrl = new URL("/admin/banners", req.url);
+    redirectUrl.searchParams.set("error", message);
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  const redirectUrl = new URL("/admin/banners", req.url);
+  redirectUrl.searchParams.set("message", "Banner baru berhasil ditambahkan");
+  return NextResponse.redirect(redirectUrl);
+}

--- a/app/api/admin/banners/utils.ts
+++ b/app/api/admin/banners/utils.ts
@@ -1,0 +1,40 @@
+export function ensureUrl(value: FormDataEntryValue | null, { allowRelative = false } = {}) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error("URL wajib diisi");
+  }
+  const trimmed = value.trim();
+  if (allowRelative && trimmed.startsWith("/")) {
+    return trimmed;
+  }
+  try {
+    const parsed = new URL(trimmed);
+    if (!parsed.protocol || !["http:", "https:"].includes(parsed.protocol)) {
+      throw new Error("URL harus menggunakan protokol http/https");
+    }
+    return trimmed;
+  } catch (error) {
+    if (allowRelative) {
+      throw new Error("URL harus dimulai dengan / atau menggunakan protokol http/https");
+    }
+    const message = error instanceof Error ? error.message : "URL tidak valid";
+    throw new Error(message);
+  }
+}
+
+export function ensureText(value: FormDataEntryValue | null, field: string) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${field} wajib diisi`);
+  }
+  return value.trim();
+}
+
+export function toNumber(value: FormDataEntryValue | null, fallback = 0) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return fallback;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error("Urutan harus berupa angka");
+  }
+  return Math.trunc(parsed);
+}

--- a/app/api/admin/products/[id]/update/route.ts
+++ b/app/api/admin/products/[id]/update/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getIronSession } from "iron-session";
+
+import { prisma } from "@/lib/prisma";
+import { sessionOptions, SessionUser } from "@/lib/session";
+
+function parseNumber(value: FormDataEntryValue | null, label: string) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`${label} wajib diisi`);
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`${label} tidak valid`);
+  }
+  return parsed;
+}
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const res = new NextResponse();
+  const session = await getIronSession<{ user?: SessionUser }>(req, res, sessionOptions);
+  const actor = session.user;
+
+  if (!actor || !actor.isAdmin) {
+    return NextResponse.json({ error: "Admin only" }, { status: 403 });
+  }
+
+  const formData = await req.formData();
+  const title = formData.get("title");
+  const category = formData.get("category");
+  const description = formData.get("description");
+  const sellerId = formData.get("sellerId");
+
+  if (typeof title !== "string" || title.trim().length === 0) {
+    return NextResponse.redirect(new URL(`/admin/products?error=${encodeURIComponent("Nama produk wajib diisi")}`, req.url));
+  }
+  if (typeof category !== "string" || category.trim().length === 0) {
+    return NextResponse.redirect(new URL(`/admin/products?error=${encodeURIComponent("Kategori wajib diisi")}`, req.url));
+  }
+
+  let price: number;
+  let stock: number;
+  try {
+    price = parseNumber(formData.get("price"), "Harga");
+    stock = parseNumber(formData.get("stock"), "Stok");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Input tidak valid";
+    const redirectUrl = new URL("/admin/products", req.url);
+    if (typeof sellerId === "string" && sellerId) {
+      redirectUrl.searchParams.set("sellerId", sellerId);
+    }
+    redirectUrl.searchParams.set("error", message);
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  try {
+    await prisma.product.update({
+      where: { id: params.id },
+      data: {
+        title: title.trim(),
+        category: category.trim(),
+        description: typeof description === "string" ? description : null,
+        price,
+        stock,
+        isActive: formData.get("isActive") === "on",
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Gagal memperbarui produk";
+    const redirectUrl = new URL("/admin/products", req.url);
+    if (typeof sellerId === "string" && sellerId) {
+      redirectUrl.searchParams.set("sellerId", sellerId);
+    }
+    redirectUrl.searchParams.set("error", message);
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  const redirectUrl = new URL("/admin/products", req.url);
+  if (typeof sellerId === "string" && sellerId) {
+    redirectUrl.searchParams.set("sellerId", sellerId);
+  }
+  redirectUrl.searchParams.set("message", "Produk berhasil diperbarui");
+  return NextResponse.redirect(redirectUrl);
+}

--- a/app/api/admin/profile-requests/[id]/approve/route.ts
+++ b/app/api/admin/profile-requests/[id]/approve/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ProfileChangeField, ProfileChangeStatus } from "@prisma/client";
+import { getIronSession } from "iron-session";
+
+import { prisma } from "@/lib/prisma";
+import { sessionOptions, SessionUser } from "@/lib/session";
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const res = new NextResponse();
+  const session = await getIronSession<{ user?: SessionUser }>(req, res, sessionOptions);
+  const actor = session.user;
+
+  if (!actor || !actor.isAdmin) {
+    return NextResponse.json({ error: "Admin only" }, { status: 403 });
+  }
+
+  const request = await prisma.profileChangeRequest.findUnique({
+    where: { id: params.id },
+    include: {
+      user: true,
+    },
+  });
+
+  if (!request || request.status !== ProfileChangeStatus.PENDING) {
+    const redirectUrl = new URL("/admin/users", req.url);
+    redirectUrl.searchParams.set("error", "Permintaan tidak ditemukan atau sudah diproses");
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  const redirectUrl = new URL("/admin/users", req.url);
+
+  try {
+    await prisma.$transaction(async (tx) => {
+      if (request.field === ProfileChangeField.STORE_NAME) {
+        await tx.user.update({
+          where: { id: request.userId },
+          data: { storeName: request.newValue },
+        });
+      } else if (request.field === ProfileChangeField.EMAIL) {
+        const duplicate = await tx.user.findUnique({ where: { email: request.newValue } });
+        if (duplicate && duplicate.id !== request.userId) {
+          throw new Error("Email sudah digunakan pengguna lain");
+        }
+        await tx.user.update({
+          where: { id: request.userId },
+          data: { email: request.newValue },
+        });
+      }
+
+      await tx.profileChangeRequest.update({
+        where: { id: request.id },
+        data: {
+          status: ProfileChangeStatus.APPROVED,
+          resolvedAt: new Date(),
+          resolvedById: actor.id,
+        },
+      });
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Gagal menyetujui permintaan";
+    redirectUrl.searchParams.set("error", message);
+    const redirectResponse = NextResponse.redirect(redirectUrl);
+    res.headers.forEach((value, key) => {
+      if (key.toLowerCase() === "set-cookie") {
+        redirectResponse.headers.append(key, value);
+      }
+    });
+    return redirectResponse;
+  }
+
+  redirectUrl.searchParams.set("message", "Permintaan profil berhasil disetujui");
+  const redirectResponse = NextResponse.redirect(redirectUrl);
+  res.headers.forEach((value, key) => {
+    if (key.toLowerCase() === "set-cookie") {
+      redirectResponse.headers.append(key, value);
+    }
+  });
+  return redirectResponse;
+}

--- a/app/api/admin/profile-requests/[id]/reject/route.ts
+++ b/app/api/admin/profile-requests/[id]/reject/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ProfileChangeStatus } from "@prisma/client";
+import { getIronSession } from "iron-session";
+
+import { prisma } from "@/lib/prisma";
+import { sessionOptions, SessionUser } from "@/lib/session";
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const res = new NextResponse();
+  const session = await getIronSession<{ user?: SessionUser }>(req, res, sessionOptions);
+  const actor = session.user;
+
+  if (!actor || !actor.isAdmin) {
+    return NextResponse.json({ error: "Admin only" }, { status: 403 });
+  }
+
+  const request = await prisma.profileChangeRequest.findUnique({ where: { id: params.id } });
+  if (!request || request.status !== ProfileChangeStatus.PENDING) {
+    const redirectUrl = new URL("/admin/users", req.url);
+    redirectUrl.searchParams.set("error", "Permintaan tidak ditemukan atau sudah diproses");
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  await prisma.profileChangeRequest.update({
+    where: { id: request.id },
+    data: {
+      status: ProfileChangeStatus.REJECTED,
+      resolvedAt: new Date(),
+      resolvedById: actor.id,
+    },
+  });
+
+  const redirectUrl = new URL("/admin/users", req.url);
+  redirectUrl.searchParams.set("message", "Permintaan profil ditolak");
+  const redirectResponse = NextResponse.redirect(redirectUrl);
+  res.headers.forEach((value, key) => {
+    if (key.toLowerCase() === "set-cookie") {
+      redirectResponse.headers.append(key, value);
+    }
+  });
+  return redirectResponse;
+}

--- a/app/api/admin/users/[id]/delete-store/route.ts
+++ b/app/api/admin/users/[id]/delete-store/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getIronSession } from "iron-session";
+
+import { StoreBadge } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { sessionOptions, SessionUser } from "@/lib/session";
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const res = new NextResponse();
+  const session = await getIronSession<{ user?: SessionUser }>(req, res, sessionOptions);
+  const actor = session.user;
+
+  if (!actor || !actor.isAdmin) {
+    return NextResponse.json({ error: "Admin only" }, { status: 403 });
+  }
+
+  const target = await prisma.user.findUnique({
+    where: { id: params.id },
+    include: {
+      products: { select: { id: true } },
+      warehouses: { select: { id: true } },
+    },
+  });
+
+  if (!target) {
+    return NextResponse.json({ error: "Pengguna tidak ditemukan" }, { status: 404 });
+  }
+
+  const redirectUrl = new URL("/admin/users", req.url);
+
+  if (target.products.length === 0 && target.warehouses.length === 0) {
+    redirectUrl.searchParams.set("error", "Pengguna ini belum memiliki toko untuk dihapus.");
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  const hasSales = await prisma.orderItem.findFirst({ where: { sellerId: params.id } });
+
+  if (hasSales) {
+    redirectUrl.searchParams.set(
+      "error",
+      "Tidak dapat menghapus toko karena memiliki riwayat penjualan yang harus dipertahankan.",
+    );
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  const defaultBadge: StoreBadge = "BASIC";
+
+  await prisma.$transaction([
+    prisma.product.deleteMany({ where: { sellerId: params.id } }),
+    prisma.warehouse.deleteMany({ where: { ownerId: params.id } }),
+    prisma.user.update({
+      where: { id: params.id },
+      data: {
+        storeIsOnline: false,
+        storeBadge: defaultBadge,
+        storeFollowers: 0,
+        storeFollowing: 0,
+        storeRating: null,
+        storeRatingCount: 0,
+      },
+    }),
+  ]);
+
+  redirectUrl.searchParams.set("message", "Toko berhasil dihapus.");
+  return NextResponse.redirect(redirectUrl);
+}

--- a/app/api/admin/users/[id]/store-badge/route.ts
+++ b/app/api/admin/users/[id]/store-badge/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getIronSession } from "iron-session";
+import { prisma } from "@/lib/prisma";
+import { sessionOptions, SessionUser } from "@/lib/session";
+
+const storeBadges = ["BASIC", "STAR", "STAR_PLUS", "MALL", "PREMIUM"] as const;
+
+type StoreBadge = (typeof storeBadges)[number];
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const res = new NextResponse();
+  const session = await getIronSession<{ user?: SessionUser }>(req, res, sessionOptions);
+  const actor = session.user;
+
+  if (!actor || !actor.isAdmin) {
+    return NextResponse.json({ error: "Admin only" }, { status: 403 });
+  }
+
+  const formData = await req.formData();
+  const badge = formData.get("badge");
+
+  if (typeof badge !== "string" || !storeBadges.includes(badge as StoreBadge)) {
+    return NextResponse.json({ error: "Badge tidak valid" }, { status: 400 });
+  }
+
+  const target = await prisma.user.findUnique({ where: { id: params.id } });
+  if (!target) {
+    return NextResponse.json({ error: "Pengguna tidak ditemukan" }, { status: 404 });
+  }
+
+  await prisma.user.update({
+    where: { id: params.id },
+    data: { storeBadge: badge as StoreBadge },
+  });
+
+  return NextResponse.redirect(new URL("/admin/users", req.url));
+}

--- a/app/api/admin/users/[id]/toggle-admin/route.ts
+++ b/app/api/admin/users/[id]/toggle-admin/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getIronSession } from "iron-session";
+import { prisma } from "@/lib/prisma";
+import { sessionOptions, SessionUser } from "@/lib/session";
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const res = new NextResponse();
+  const session = await getIronSession<{ user?: SessionUser }>(req, res, sessionOptions);
+  const actor = session.user;
+
+  if (!actor || !actor.isAdmin) {
+    return NextResponse.json({ error: "Admin only" }, { status: 403 });
+  }
+
+  if (params.id === actor.id) {
+    return NextResponse.json({ error: "Tidak dapat mengubah status sendiri" }, { status: 400 });
+  }
+
+  const target = await prisma.user.findUnique({ where: { id: params.id } });
+  if (!target) {
+    return NextResponse.json({ error: "Pengguna tidak ditemukan" }, { status: 404 });
+  }
+
+  await prisma.user.update({
+    where: { id: params.id },
+    data: { isAdmin: !target.isAdmin },
+  });
+
+  return NextResponse.redirect(new URL("/admin/users", req.url));
+}

--- a/app/api/admin/users/[id]/toggle-store/route.ts
+++ b/app/api/admin/users/[id]/toggle-store/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getIronSession } from "iron-session";
+import { prisma } from "@/lib/prisma";
+import { sessionOptions, SessionUser } from "@/lib/session";
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const res = new NextResponse();
+  const session = await getIronSession<{ user?: SessionUser }>(req, res, sessionOptions);
+  const actor = session.user;
+
+  if (!actor || !actor.isAdmin) {
+    return NextResponse.json({ error: "Admin only" }, { status: 403 });
+  }
+
+  const target = await prisma.user.findUnique({ where: { id: params.id } });
+  if (!target) {
+    return NextResponse.json({ error: "Pengguna tidak ditemukan" }, { status: 404 });
+  }
+
+  await prisma.user.update({
+    where: { id: params.id },
+    data: { storeIsOnline: !target.storeIsOnline },
+  });
+
+  return NextResponse.redirect(new URL("/admin/users", req.url));
+}

--- a/app/api/admin/users/[id]/update-profile/route.ts
+++ b/app/api/admin/users/[id]/update-profile/route.ts
@@ -1,0 +1,145 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getIronSession } from "iron-session";
+
+import { ProfileChangeStatus, StoreBadge } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { sessionOptions, SessionUser } from "@/lib/session";
+
+type StoreBadgeValue = (typeof StoreBadge)[keyof typeof StoreBadge];
+
+function safeNumber(value: FormDataEntryValue | null, options?: { min?: number }) {
+  if (typeof value !== "string" || value.trim() === "") {
+    return undefined;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error("Input numerik tidak valid");
+  }
+  if (typeof options?.min === "number" && parsed < options.min) {
+    throw new Error("Nilai numerik terlalu kecil");
+  }
+  return parsed;
+}
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const res = new NextResponse();
+  const session = await getIronSession<{ user?: SessionUser }>(req, res, sessionOptions);
+  const actor = session.user;
+
+  if (!actor || !actor.isAdmin) {
+    return NextResponse.json({ error: "Admin only" }, { status: 403 });
+  }
+
+  const formData = await req.formData();
+
+  const name = formData.get("name");
+  const storeName = formData.get("storeName");
+  const email = formData.get("email");
+  const slug = formData.get("slug");
+  const badge = formData.get("badge");
+  const storeIsOnline = formData.get("storeIsOnline") === "on";
+  const avatarUrl = formData.get("avatarUrl");
+
+  if (typeof name !== "string" || name.trim().length === 0) {
+    return NextResponse.redirect(new URL(`/admin/users?error=${encodeURIComponent("Nama wajib diisi")}`, req.url));
+  }
+  if (typeof storeName !== "string" || storeName.trim().length === 0) {
+    return NextResponse.redirect(
+      new URL(`/admin/users?error=${encodeURIComponent("Nama toko wajib diisi")}`, req.url),
+    );
+  }
+  if (typeof email !== "string" || email.trim().length === 0) {
+    return NextResponse.redirect(new URL(`/admin/users?error=${encodeURIComponent("Email wajib diisi")}`, req.url));
+  }
+  if (typeof slug !== "string" || slug.trim().length === 0) {
+    return NextResponse.redirect(new URL(`/admin/users?error=${encodeURIComponent("Slug wajib diisi")}`, req.url));
+  }
+  if (typeof badge !== "string") {
+    return NextResponse.redirect(new URL(`/admin/users?error=${encodeURIComponent("Badge tidak valid")}`, req.url));
+  }
+  const allowedBadges = Object.values(StoreBadge);
+  if (!allowedBadges.includes(badge as StoreBadgeValue)) {
+    return NextResponse.redirect(new URL(`/admin/users?error=${encodeURIComponent("Badge tidak ditemukan")}`, req.url));
+  }
+
+  let avatarUrlValue: string | null | undefined = undefined;
+  if (typeof avatarUrl === "string") {
+    const trimmed = avatarUrl.trim();
+    if (trimmed.length === 0) {
+      avatarUrlValue = null;
+    } else {
+      try {
+        const parsed = new URL(trimmed);
+        if (!["http:", "https:"].includes(parsed.protocol)) {
+          throw new Error("URL foto harus menggunakan protokol http/https");
+        }
+        avatarUrlValue = trimmed;
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "URL foto profil tidak valid";
+        return NextResponse.redirect(
+          new URL(`/admin/users?error=${encodeURIComponent(message)}`, req.url),
+        );
+      }
+    }
+  }
+
+  let storeRating: number | undefined;
+  let storeRatingCount: number | undefined;
+  let storeFollowers: number | undefined;
+  let storeFollowing: number | undefined;
+
+  try {
+    storeRating = safeNumber(formData.get("storeRating"), { min: 0 });
+    if (typeof storeRating !== "undefined" && storeRating > 5) {
+      throw new Error("Rating maksimal 5");
+    }
+    storeRatingCount = safeNumber(formData.get("storeRatingCount"), { min: 0 });
+    storeFollowers = safeNumber(formData.get("storeFollowers"), { min: 0 });
+    storeFollowing = safeNumber(formData.get("storeFollowing"), { min: 0 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Input tidak valid";
+    return NextResponse.redirect(
+      new URL(`/admin/users?error=${encodeURIComponent(message)}`, req.url),
+    );
+  }
+
+  try {
+    await prisma.$transaction(async (tx) => {
+      await tx.user.update({
+        where: { id: params.id },
+        data: {
+          name: name.trim(),
+          storeName: storeName.trim(),
+          email: email.trim().toLowerCase(),
+          slug: slug.trim().toLowerCase(),
+          storeBadge: badge as StoreBadgeValue,
+          storeIsOnline,
+          storeRating,
+          storeRatingCount,
+          storeFollowers,
+          storeFollowing,
+          avatarUrl: avatarUrlValue,
+        },
+      });
+
+      await tx.profileChangeRequest.deleteMany({
+        where: {
+          userId: params.id,
+          status: ProfileChangeStatus.PENDING,
+          field: { in: ["STORE_NAME", "EMAIL"] },
+        },
+      });
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Gagal memperbarui pengguna";
+    const redirectUrl = new URL("/admin/users", req.url);
+    redirectUrl.searchParams.set("error", message);
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  const redirectUrl = new URL("/admin/users", req.url);
+  redirectUrl.searchParams.set("message", "Data seller berhasil diperbarui");
+  return NextResponse.redirect(redirectUrl);
+}

--- a/app/api/cart/add/route.ts
+++ b/app/api/cart/add/route.ts
@@ -1,12 +1,18 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { getPrimaryProductImageSrc } from "@/lib/productImages";
 
 export async function POST(req: NextRequest) {
   const form = await req.formData();
   const productId = String(form.get('productId') || '');
   const qty = parseInt(String(form.get('qty') || '1')) || 1;
-  const p = await prisma.product.findUnique({ where: { id: productId } });
+  const p = await prisma.product.findUnique({
+    where: { id: productId },
+    include: { images: { orderBy: { sortOrder: 'asc' }, select: { id: true } } },
+  });
   if (!p || !p.isActive) return new Response('Produk tidak ditemukan', { status: 404 });
+
+  const thumbnail = getPrimaryProductImageSrc(p);
 
   const html = `<!doctype html><html><body>
 <script>
@@ -14,7 +20,7 @@ var cart = JSON.parse(localStorage.getItem('cart')||'[]');
 var idx = cart.findIndex(it => it.productId === ${JSON.stringify(p.id)});
 if (idx >= 0) { cart[idx].qty += ${qty}; }
 else {
-  cart.push({ productId: ${JSON.stringify(p.id)}, title: ${JSON.stringify(p.title)}, price: ${p.price}, qty: ${qty}, imageUrl: ${JSON.stringify(p.imageUrl||'')}, sellerId: ${JSON.stringify(p.sellerId)} });
+  cart.push({ productId: ${JSON.stringify(p.id)}, title: ${JSON.stringify(p.title)}, price: ${p.price}, qty: ${qty}, imageUrl: ${JSON.stringify(thumbnail)}, sellerId: ${JSON.stringify(p.sellerId)} });
 }
 localStorage.setItem('cart', JSON.stringify(cart));
 location.href = '/cart';

--- a/app/api/products/[productId]/images/[imageId]/route.ts
+++ b/app/api/products/[productId]/images/[imageId]/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(_req: NextRequest, { params }: { params: { productId: string; imageId: string } }) {
+  const image = await prisma.productImage.findFirst({
+    where: { id: params.imageId, productId: params.productId },
+  });
+
+  if (!image) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const body = new Uint8Array(image.data);
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": image.mimeType,
+      "Cache-Control": "public, max-age=86400, immutable",
+    },
+  });
+}

--- a/app/api/seed/route.ts
+++ b/app/api/seed/route.ts
@@ -23,5 +23,43 @@ export async function GET(req: NextRequest) {
   if (!v) {
     await prisma.voucher.create({ data: { code: 'AKAY10', kind: 'PERCENT', value: 10, minSpend: 100000, active: true } });
   }
+
+  const bannerCount = await prisma.promoBanner.count();
+  if (bannerCount === 0) {
+    await prisma.promoBanner.createMany({
+      data: [
+        {
+          title: 'Promo Spesial Minggu Ini',
+          description: 'Nikmati potongan harga hingga 40% untuk produk pilihan.',
+          highlight: 'Diskon Terbatas',
+          imageUrl: 'https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=1200&q=80',
+          ctaLabel: 'Belanja Sekarang',
+          ctaHref: '/product',
+          sortOrder: 0,
+          isActive: true,
+        },
+        {
+          title: 'Gratis Ongkir ke Seluruh Indonesia',
+          description: 'Belanja sekarang dan dapatkan pengiriman gratis tanpa minimum belanja.',
+          highlight: 'Ongkir 0 Rupiah',
+          imageUrl: 'https://images.unsplash.com/photo-1523275335684-37898b6baf30?auto=format&fit=crop&w=1200&q=80',
+          ctaLabel: 'Lihat Promo',
+          ctaHref: '/product',
+          sortOrder: 1,
+          isActive: true,
+        },
+        {
+          title: 'Flash Sale Setiap Hari',
+          description: 'Produk favorit dengan harga spesial hadir setiap hari jam 12.00-15.00.',
+          highlight: '3 Jam Saja',
+          imageUrl: 'https://images.unsplash.com/photo-1483478550801-ceba5fe50e8e?auto=format&fit=crop&w=1200&q=80',
+          ctaLabel: 'Ikuti Flash Sale',
+          ctaHref: '/product',
+          sortOrder: 2,
+          isActive: true,
+        },
+      ],
+    });
+  }
   return NextResponse.json({ ok: true });
 }

--- a/app/api/users/[userId]/avatar/route.ts
+++ b/app/api/users/[userId]/avatar/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+
+export async function GET(_req: NextRequest, { params }: { params: { userId: string } }) {
+  const avatar = await prisma.userAvatar.findUnique({ where: { userId: params.userId } });
+  if (!avatar) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const body = new Uint8Array(avatar.data);
+
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "Content-Type": avatar.mimeType,
+      "Cache-Control": "public, max-age=0, must-revalidate",
+    },
+  });
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,19 +2,68 @@ import Link from "next/link";
 
 import { prisma } from "@/lib/prisma";
 import { formatIDR } from "@/lib/utils";
-import { PromoSlider } from "@/components/PromoSlider";
+import { PromoSlider, PromoSlide } from "@/components/PromoSlider";
 import { getCategoryInfo, productCategories } from "@/lib/categories";
+import { getPrimaryProductImageSrc } from "@/lib/productImages";
+
+const fallbackSlides: PromoSlide[] = [
+  {
+    title: "Promo Spesial Minggu Ini",
+    description: "Nikmati potongan harga hingga 40% untuk produk pilihan.",
+    highlight: "Diskon Terbatas",
+    imageUrl:
+      "https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=1200&q=80",
+    ctaLabel: "Belanja Sekarang",
+    ctaHref: "/product",
+  },
+  {
+    title: "Gratis Ongkir ke Seluruh Indonesia",
+    description: "Belanja sekarang dan dapatkan pengiriman gratis tanpa minimum belanja.",
+    highlight: "Ongkir 0 Rupiah",
+    imageUrl:
+      "https://images.unsplash.com/photo-1523275335684-37898b6baf30?auto=format&fit=crop&w=1200&q=80",
+    ctaLabel: "Lihat Promo",
+    ctaHref: "/product",
+  },
+  {
+    title: "Flash Sale Setiap Hari",
+    description: "Produk favorit dengan harga spesial hadir setiap hari jam 12.00-15.00.",
+    highlight: "3 Jam Saja",
+    imageUrl:
+      "https://images.unsplash.com/photo-1483478550801-ceba5fe50e8e?auto=format&fit=crop&w=1200&q=80",
+    ctaLabel: "Ikuti Flash Sale",
+    ctaHref: "/product",
+  },
+];
 
 export default async function HomePage() {
   const products = await prisma.product.findMany({
     where: { isActive: true },
     orderBy: { createdAt: 'desc' },
-    include: { seller: true }
+    include: {
+      seller: true,
+      images: { select: { id: true }, orderBy: { sortOrder: 'asc' } },
+    }
   });
+  const promoBanners = await prisma.promoBanner.findMany({
+    where: { isActive: true },
+    orderBy: [
+      { sortOrder: "asc" },
+      { createdAt: "asc" },
+    ],
+  });
+  const slides: PromoSlide[] = promoBanners.map((banner) => ({
+    title: banner.title,
+    description: banner.description,
+    highlight: banner.highlight,
+    imageUrl: banner.imageUrl,
+    ctaLabel: banner.ctaLabel,
+    ctaHref: banner.ctaHref,
+  }));
   const categories = productCategories;
   return (
     <div className="space-y-10">
-      <PromoSlider />
+      <PromoSlider slides={slides.length > 0 ? slides : fallbackSlides} />
 
       <section>
         <h2 className="mb-4 text-xl font-semibold">Kategori Populer</h2>
@@ -52,6 +101,9 @@ export default async function HomePage() {
             const showOriginal = originalPrice !== null && originalPrice > p.price;
             const categoryLabel = category?.name ?? p.category.replace(/-/g, ' ');
             const categoryEmoji = category?.emoji ?? '🏷️';
+            const sellerName = p.seller.storeName?.trim().length
+              ? p.seller.storeName
+              : p.seller.name;
             return (
               <div
                 key={p.id}
@@ -59,7 +111,7 @@ export default async function HomePage() {
               >
                 <Link href={`/product/${p.id}`} className="block">
                   <img
-                    src={p.imageUrl || 'https://placehold.co/600x400?text=Produk'}
+                    src={getPrimaryProductImageSrc(p)}
                     className="h-40 w-full object-cover"
                     alt={p.title}
                   />
@@ -75,7 +127,7 @@ export default async function HomePage() {
                   <div className="text-sm text-gray-500">
                     Seller:{' '}
                     <Link className="underline hover:text-indigo-600" href={`/s/${p.seller.slug}`}>
-                      {p.seller.name}
+                      {sellerName}
                     </Link>
                   </div>
                   {showOriginal && (

--- a/app/seller/dashboard/page.tsx
+++ b/app/seller/dashboard/page.tsx
@@ -1,32 +1,249 @@
+import Link from "next/link";
+
 import { prisma } from "@/lib/prisma";
 import { getSession } from "@/lib/session";
 
-export default async function Dashboard() {
-  const session = await getSession();
-  const user = session.user;
-  if (!user) return <div>Harap login sebagai seller.</div>;
+type DashboardProps = {
+  searchParams?: Record<string, string | string[] | undefined>;
+};
 
-  const [pcount, orders, revenue] = await Promise.all([
-    prisma.product.count({ where: { sellerId: user.id } }),
-    prisma.orderItem.findMany({ where: { sellerId: user.id }, select: { orderId: true }, distinct: ["orderId"] }),
-    prisma.orderItem.aggregate({ where: { sellerId: user.id, order: { status: 'PAID' } }, _sum: { price: true } })
-  ]);
+function getMessage(searchParams?: Record<string, string | string[] | undefined>) {
+  if (!searchParams) return {} as { success?: string; error?: string };
+  const successParam = searchParams.message;
+  const errorParam = searchParams.error;
+  const success = Array.isArray(successParam) ? successParam[0] : successParam;
+  const error = Array.isArray(errorParam) ? errorParam[0] : errorParam;
+  return {
+    success,
+    error,
+  };
+}
+
+export default async function Dashboard({ searchParams }: DashboardProps) {
+  const session = await getSession();
+  const sessionUser = session.user;
+  if (!sessionUser) {
+    return (
+      <div className="rounded border border-orange-200 bg-orange-50 p-6 text-center text-sm text-orange-700">
+        Harap login sebagai seller untuk mengelola akun Anda.
+      </div>
+    );
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: sessionUser.id },
+    include: {
+      profileChangeRequests: {
+        where: { status: "PENDING" },
+        orderBy: { createdAt: "asc" },
+      },
+    },
+  });
+
+  if (!user) {
+    return (
+      <div className="rounded border border-red-200 bg-red-50 p-6 text-center text-sm text-red-700">
+        Data akun tidak ditemukan.
+      </div>
+    );
+  }
+
+  const pendingStoreName = user.profileChangeRequests.find((req) => req.field === "STORE_NAME");
+  const pendingEmail = user.profileChangeRequests.find((req) => req.field === "EMAIL");
+  const currentStoreName = user.storeName?.trim().length ? user.storeName : user.name;
+  const storeNameInputValue = pendingStoreName?.newValue ?? currentStoreName ?? "";
+  const emailInputValue = pendingEmail?.newValue ?? user.email ?? "";
+
+  const { success, error } = getMessage(searchParams);
 
   return (
-    <div>
-      <h1 className="text-2xl font-semibold mb-4">Dashboard Seller</h1>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div className="bg-white border rounded p-4"><div className="text-sm text-gray-500">Produk</div><div className="text-2xl font-bold">{pcount}</div></div>
-        <div className="bg-white border rounded p-4"><div className="text-sm text-gray-500">Pesanan</div><div className="text-2xl font-bold">{orders.length}</div></div>
-        <div className="bg-white border rounded p-4"><div className="text-sm text-gray-500">Omzet (Paid)</div><div className="text-2xl font-bold">Rp {new Intl.NumberFormat('id-ID').format(revenue._sum.price || 0)}</div></div>
-      </div>
-      <div className="mt-6 flex gap-2">
-        <a className="btn-primary" href="/seller/products">Kelola Produk</a>
-        <a className="btn-outline" href="/seller/orders">Pesanan Saya</a>
-        <a className="btn-outline" href="/seller/warehouses">Gudang</a>
-        <a className="btn-outline" href="/seller/returns">Retur</a>
-        <a className="btn-outline" href={`/s/${user.slug}`} target="_blank">Lihat Toko</a>
-      </div>
+    <div className="mx-auto grid max-w-6xl gap-8 px-4 py-10 lg:grid-cols-[240px,1fr]">
+      <aside className="space-y-6">
+        <div>
+          <h1 className="text-xl font-semibold text-gray-900">Akun Saya</h1>
+          <p className="mt-1 text-sm text-gray-500">
+            Kelola informasi penting untuk melindungi dan mengamankan akun Anda.
+          </p>
+        </div>
+        <nav className="hidden flex-col gap-1 rounded-lg border border-gray-200 bg-white p-4 text-sm font-medium text-gray-600 lg:flex">
+          <span className="rounded-md bg-orange-500/10 px-3 py-2 text-orange-600">Profil</span>
+          <Link className="rounded-md px-3 py-2 hover:bg-gray-50" href="/seller/orders">
+            Pesanan Saya
+          </Link>
+          <Link className="rounded-md px-3 py-2 hover:bg-gray-50" href="/seller/products">
+            Produk
+          </Link>
+          <Link className="rounded-md px-3 py-2 hover:bg-gray-50" href="/seller/warehouses">
+            Gudang &amp; Pengiriman
+          </Link>
+        </nav>
+      </aside>
+
+      <section className="space-y-6">
+        {(success || error) && (
+          <div
+            className={`rounded border px-4 py-3 text-sm ${
+              success
+                ? "border-emerald-200 bg-emerald-50 text-emerald-700"
+                : "border-red-200 bg-red-50 text-red-700"
+            }`}
+          >
+            {success ?? error}
+          </div>
+        )}
+
+        <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+          <div className="border-b border-gray-100 bg-gray-50 px-6 py-4">
+            <h2 className="text-lg font-semibold text-gray-900">Profil Saya</h2>
+            <p className="mt-1 text-sm text-gray-500">
+              Pastikan data akun selalu terbaru untuk pengalaman belanja yang optimal.
+            </p>
+          </div>
+          <div className="space-y-6 px-6 py-6">
+            <div className="flex flex-col gap-6 lg:flex-row lg:items-start">
+              <div className="flex flex-col items-center gap-4 text-center lg:w-56 lg:text-left">
+                <div className="h-24 w-24 overflow-hidden rounded-full border border-gray-200 bg-gray-100">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={user.avatarUrl?.trim() ? user.avatarUrl : "https://placehold.co/120x120?text=AK"}
+                    alt={user.name ?? "Foto profil"}
+                    className="h-full w-full object-cover"
+                  />
+                </div>
+                <form
+                  className="flex w-full flex-col items-center gap-3 text-sm lg:items-stretch"
+                  action="/api/account/avatar"
+                  method="POST"
+                  encType="multipart/form-data"
+                >
+                  <label
+                    htmlFor="avatar"
+                    className="inline-flex w-full cursor-pointer items-center justify-center gap-2 rounded-md border border-gray-300 px-4 py-2 font-medium text-gray-700 transition hover:border-orange-400 hover:text-orange-600"
+                  >
+                    Pilih Gambar
+                  </label>
+                  <input
+                    id="avatar"
+                    name="avatar"
+                    type="file"
+                    accept="image/png,image/jpeg,image/webp"
+                    className="hidden"
+                    required
+                  />
+                  <button
+                    type="submit"
+                    className="inline-flex w-full items-center justify-center rounded-md bg-orange-500 px-4 py-2 font-medium text-white transition hover:bg-orange-600"
+                  >
+                    Simpan Foto
+                  </button>
+                  <p className="text-xs text-gray-500">Ukuran gambar maks. 1 MB (format .jpg, .png, .webp).</p>
+                </form>
+              </div>
+
+              <div className="flex-1">
+                <form action="/api/account/profile" method="POST" className="space-y-5">
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <label className="flex flex-col gap-1 text-sm">
+                      <span className="font-medium text-gray-700">Nama Pemilik</span>
+                      <input
+                        type="text"
+                        name="name"
+                        defaultValue={user.name ?? ""}
+                        required
+                        className="rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-200"
+                      />
+                      <span className="text-xs text-gray-500">
+                        Nama ini digunakan untuk komunikasi internal dan tidak perlu persetujuan admin.
+                      </span>
+                    </label>
+                    <label className="flex flex-col gap-1 text-sm">
+                      <span className="font-medium text-gray-700">Nama Toko</span>
+                      <input
+                        type="text"
+                        name="storeName"
+                        defaultValue={storeNameInputValue}
+                        required
+                        className={`rounded-md border px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 ${
+                          pendingStoreName
+                            ? "border-amber-300 focus:border-amber-400 focus:ring-amber-200"
+                            : "border-gray-300 focus:border-orange-500 focus:ring-orange-200"
+                        }`}
+                      />
+                      <span className="text-xs text-gray-500">
+                        {pendingStoreName
+                          ? "Menunggu persetujuan admin. Anda dapat memperbarui permintaan bila perlu."
+                          : "Perubahan nama toko memerlukan persetujuan admin."}
+                      </span>
+                    </label>
+                    <label className="flex flex-col gap-1 text-sm">
+                      <span className="font-medium text-gray-700">Email</span>
+                      <input
+                        type="email"
+                        name="email"
+                        defaultValue={emailInputValue}
+                        required
+                        className={`rounded-md border px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 ${
+                          pendingEmail
+                            ? "border-amber-300 focus:border-amber-400 focus:ring-amber-200"
+                            : "border-gray-300 focus:border-orange-500 focus:ring-orange-200"
+                        }`}
+                      />
+                      <span className="text-xs text-gray-500">
+                        {pendingEmail
+                          ? "Perubahan email sedang menunggu persetujuan admin."
+                          : "Perubahan email akan diverifikasi terlebih dahulu oleh admin."}
+                      </span>
+                    </label>
+                    <label className="flex flex-col gap-1 text-sm">
+                      <span className="font-medium text-gray-700">Slug Toko</span>
+                      <input
+                        type="text"
+                        name="slug"
+                        defaultValue={user.slug ?? ""}
+                        disabled
+                        className="cursor-not-allowed rounded-md border border-gray-200 bg-gray-100 px-3 py-2 text-sm text-gray-500"
+                      />
+                      <span className="text-xs text-gray-500">Hubungi admin bila Anda perlu mengubah tautan toko.</span>
+                    </label>
+                  </div>
+                  <div className="flex flex-col gap-3 rounded-md bg-orange-50 px-4 py-3 text-sm text-orange-700">
+                    <div>
+                      Nama toko aktif saat ini:
+                      <span className="ml-1 font-semibold text-orange-600">{currentStoreName}</span>
+                    </div>
+                    <div>Email aktif: <span className="font-semibold text-orange-600">{user.email}</span></div>
+                  </div>
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
+                    <Link
+                      href={`/s/${user.slug}`}
+                      className="inline-flex items-center justify-center rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:border-orange-400 hover:text-orange-600"
+                    >
+                      Lihat Halaman Toko
+                    </Link>
+                    <button
+                      type="submit"
+                      className="inline-flex items-center justify-center rounded-md bg-orange-500 px-5 py-2 text-sm font-semibold text-white transition hover:bg-orange-600"
+                    >
+                      Simpan Perubahan
+                    </button>
+                  </div>
+                </form>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 p-6 text-sm text-gray-600">
+          <h3 className="text-base font-semibold text-gray-800">Butuh bantuan?</h3>
+          <p className="mt-2">
+            Jika Anda memiliki kendala terkait perubahan data akun, hubungi tim admin melalui menu Bantuan atau email
+            <a className="ml-1 font-medium text-orange-600 hover:underline" href="mailto:support@akay.id">
+              support@akay.id
+            </a>
+            .
+          </p>
+        </div>
+      </section>
     </div>
   );
 }

--- a/app/seller/orders/page.tsx
+++ b/app/seller/orders/page.tsx
@@ -17,7 +17,7 @@ export default async function SellerOrders() {
       <h1 className="text-2xl font-semibold mb-4">Pesanan (Produk Saya)</h1>
       <div className="bg-white border rounded p-4">
         <table className="w-full text-sm">
-          <thead><tr className="text-left border-b"><th className="py-2">Tanggal</th><th>Kode</th><th>Status</th><th>Metode</th><th>Subtotal Saya</th><th>Aksi</th></tr></thead>
+          <thead><tr className="text-left border-b"><th className="py-2">Tanggal</th><th>Kode</th><th>Status</th><th>Metode</th><th>Subtotal Saya</th><th>Item</th><th>Aksi</th></tr></thead>
           <tbody>
             {orders.map(o => {
               const subtotal = o.items.reduce((s, it) => s + it.qty*it.price, 0);
@@ -28,27 +28,38 @@ export default async function SellerOrders() {
                   <td><span className={`badge ${o.status === 'PAID' ? 'badge-paid':'badge-pending'}`}>{o.status}</span></td>
                   <td>{o.paymentMethod}</td>
                   <td>Rp {new Intl.NumberFormat('id-ID').format(subtotal)}</td>
-                  <td><a className="link" href={`/order/${o.orderCode}`} target="_blank">Detail</a></td>
+                  <td className="py-2 align-top">
+                    <div className="space-y-3">
+                      {o.items.map(item => (
+                        <div key={item.id} className="border rounded px-3 py-2 bg-gray-50">
+                          <div className="flex justify-between gap-3">
+                            <div>
+                              <div className="font-medium">{item.product.title}</div>
+                              <div className="text-xs text-gray-500">Qty: {item.qty} • Rp {new Intl.NumberFormat('id-ID').format(item.price)}</div>
+                            </div>
+                            <span className={`badge ${item.status === 'PENDING' ? 'badge-pending' : 'badge-paid'}`}>{item.status}</span>
+                          </div>
+                          <form method="POST" action="/api/seller/item-status" className="mt-3 flex flex-col md:flex-row md:items-center gap-2">
+                            <input type="hidden" name="orderCode" value={o.orderCode} />
+                            <input type="hidden" name="orderItemId" value={item.id} />
+                            <select name="status" defaultValue={item.status} className="border rounded px-3 py-2 text-sm">
+                              <option value="PENDING">PENDING</option>
+                              <option value="PACKED">PACKED</option>
+                              <option value="SHIPPED">SHIPPED</option>
+                              <option value="DELIVERED">DELIVERED</option>
+                            </select>
+                            <button className="btn-primary text-sm">Update</button>
+                          </form>
+                        </div>
+                      ))}
+                    </div>
+                  </td>
+                  <td className="py-2 align-top"><a className="link" href={`/order/${o.orderCode}`} target="_blank">Detail</a></td>
                 </tr>
               );
             })}
           </tbody>
         </table>
-      </div>
-      <div className="mt-6 bg-white border rounded p-4">
-        <h2 className="font-semibold mb-2">Update Status Item</h2>
-        <form method="POST" action="/api/seller/item-status" className="grid grid-cols-1 md:grid-cols-4 gap-3">
-          <input name="orderCode" required placeholder="Kode Pesanan (ORD-...)" className="border rounded px-3 py-2"/>
-          <input name="orderItemId" required placeholder="OrderItem ID" className="border rounded px-3 py-2"/>
-          <select name="status" className="border rounded px-3 py-2">
-            <option value="PENDING">PENDING</option>
-            <option value="PACKED">PACKED</option>
-            <option value="SHIPPED">SHIPPED</option>
-            <option value="DELIVERED">DELIVERED</option>
-          </select>
-          <button className="btn-primary">Update</button>
-        </form>
-        <p className="text-xs text-gray-500 mt-2">* Dapatkan OrderItem ID di JSON order: /api/orders/ORD-XXXX</p>
       </div>
     </div>
   );

--- a/app/seller/products/page.tsx
+++ b/app/seller/products/page.tsx
@@ -21,7 +21,12 @@ export default async function SellerProducts() {
       <h1 className="text-2xl font-semibold mb-4">Produk Saya</h1>
       <div className="bg-white border rounded p-4 mb-6">
         <h2 className="font-semibold mb-2">Tambah Produk</h2>
-        <form method="POST" action="/api/seller/products/create" className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <form
+          method="POST"
+          action="/api/seller/products/create"
+          encType="multipart/form-data"
+          className="grid grid-cols-1 md:grid-cols-2 gap-3"
+        >
           <select name="category" required className="border rounded px-3 py-2 md:col-span-2">
             <option value="">Pilih Kategori Produk</option>
             {productCategories.map((category) => (
@@ -43,7 +48,19 @@ export default async function SellerProducts() {
             className="border rounded px-3 py-2"
           />
           <input name="stock" type="number" placeholder="Stok" className="border rounded px-3 py-2"/>
-          <input name="imageUrl" placeholder="URL gambar" className="border rounded px-3 py-2"/>
+          <label className="md:col-span-2 text-sm">
+            <span className="mb-1 block font-medium">Gambar Produk</span>
+            <input
+              name="images"
+              type="file"
+              accept="image/*"
+              multiple
+              className="w-full rounded border px-3 py-2"
+            />
+            <span className="mt-1 block text-xs text-gray-500">
+              Unggah hingga 5 gambar. Gambar pertama akan menjadi thumbnail utama.
+            </span>
+          </label>
           <textarea name="description" placeholder="Deskripsi" className="border rounded px-3 py-2 md:col-span-2"></textarea>
           <textarea
             name="variants"

--- a/components/PromoSlider.tsx
+++ b/components/PromoSlider.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
-type Slide = {
+export type PromoSlide = {
   title: string;
   description: string;
   highlight: string;
@@ -12,46 +12,42 @@ type Slide = {
   ctaHref: string;
 };
 
-export function PromoSlider({ className }: { className?: string }) {
-  const slides = useMemo<Slide[]>(
-    () => [
-      {
-        title: "Promo Spesial Minggu Ini",
-        description: "Nikmati potongan harga hingga 40% untuk produk pilihan.",
-        highlight: "Diskon Terbatas",
-        imageUrl: "https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=1200&q=80",
-        ctaLabel: "Belanja Sekarang",
-        ctaHref: "/product"
-      },
-      {
-        title: "Gratis Ongkir ke Seluruh Indonesia",
-        description: "Belanja sekarang dan dapatkan pengiriman gratis tanpa minimum belanja.",
-        highlight: "Ongkir 0 Rupiah",
-        imageUrl: "https://images.unsplash.com/photo-1523275335684-37898b6baf30?auto=format&fit=crop&w=1200&q=80",
-        ctaLabel: "Lihat Promo",
-        ctaHref: "/product"
-      },
-      {
-        title: "Flash Sale Setiap Hari",
-        description: "Produk favorit dengan harga spesial hadir setiap hari jam 12.00-15.00.",
-        highlight: "3 Jam Saja",
-        imageUrl: "https://images.unsplash.com/photo-1483478550801-ceba5fe50e8e?auto=format&fit=crop&w=1200&q=80",
-        ctaLabel: "Ikuti Flash Sale",
-        ctaHref: "/product"
-      }
-    ],
-    []
-  );
-
+export function PromoSlider({
+  className,
+  slides,
+}: {
+  className?: string;
+  slides: PromoSlide[];
+}) {
   const [activeIndex, setActiveIndex] = useState(0);
 
   useEffect(() => {
+    setActiveIndex(0);
+  }, [slides.length]);
+
+  useEffect(() => {
+    if (slides.length === 0) {
+      return;
+    }
+
     const interval = setInterval(() => {
       setActiveIndex((prev) => (prev + 1) % slides.length);
     }, 6000);
 
     return () => clearInterval(interval);
   }, [slides.length]);
+
+  if (slides.length === 0) {
+    return (
+      <div
+        className={`rounded-2xl border border-dashed border-gray-300 bg-white p-10 text-center text-sm text-gray-500 ${
+          className ?? ""
+        }`}
+      >
+        Belum ada banner promo yang aktif.
+      </div>
+    );
+  }
 
   return (
     <div
@@ -62,7 +58,7 @@ export function PromoSlider({ className }: { className?: string }) {
       <div className="relative min-h-[240px]">
         {slides.map((slide, index) => (
           <div
-            key={slide.title}
+            key={`${slide.title}-${index}`}
             className={`absolute inset-0 flex flex-col gap-6 p-8 transition-all duration-700 ease-in-out md:flex-row md:items-center ${
               index === activeIndex
                 ? "opacity-100 translate-x-0"
@@ -100,7 +96,7 @@ export function PromoSlider({ className }: { className?: string }) {
       <div className="absolute bottom-4 left-0 right-0 flex items-center justify-center gap-2">
         {slides.map((slide, index) => (
           <button
-            key={slide.title}
+            key={`${slide.title}-${index}`}
             className={`h-2.5 rounded-full transition-all duration-300 ${
               index === activeIndex ? "w-8 bg-white" : "w-2 bg-white/60 hover:bg-white"
             }`}

--- a/lib/productImages.ts
+++ b/lib/productImages.ts
@@ -1,0 +1,30 @@
+import type { ProductImage } from "@prisma/client";
+
+export const PRODUCT_IMAGE_PLACEHOLDER = "https://placehold.co/600x400?text=Produk";
+
+export function buildProductImageUrl(productId: string, imageId: string) {
+  return `/api/products/${productId}/images/${imageId}`;
+}
+
+type ProductWithImages = {
+  id: string;
+  imageUrl?: string | null;
+  images?: Pick<ProductImage, "id">[] | null;
+};
+
+export function getPrimaryProductImageSrc(product: ProductWithImages) {
+  if (product.images && product.images.length > 0) {
+    return buildProductImageUrl(product.id, product.images[0]!.id);
+  }
+  if (product.imageUrl) {
+    return product.imageUrl;
+  }
+  return PRODUCT_IMAGE_PLACEHOLDER;
+}
+
+export function getProductImageSources(productId: string, images: Pick<ProductImage, "id">[]) {
+  return images.map((image) => ({
+    id: image.id,
+    src: buildProductImageUrl(productId, image.id),
+  }));
+}

--- a/prisma/migrations/20251004000006_add_user_avatar_url/migration.sql
+++ b/prisma/migrations/20251004000006_add_user_avatar_url/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "User"
+  ADD COLUMN "avatarUrl" TEXT;

--- a/prisma/migrations/20251004000007_add_promo_banners/migration.sql
+++ b/prisma/migrations/20251004000007_add_promo_banners/migration.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "PromoBanner" (
+  "id" SERIAL PRIMARY KEY,
+  "title" TEXT NOT NULL,
+  "description" TEXT NOT NULL,
+  "highlight" TEXT NOT NULL,
+  "imageUrl" TEXT NOT NULL,
+  "ctaLabel" TEXT NOT NULL,
+  "ctaHref" TEXT NOT NULL,
+  "sortOrder" INTEGER NOT NULL DEFAULT 0,
+  "isActive" BOOLEAN NOT NULL DEFAULT TRUE,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/prisma/migrations/20251004000008_add_product_images/migration.sql
+++ b/prisma/migrations/20251004000008_add_product_images/migration.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "ProductImage" (
+    "id" TEXT NOT NULL,
+    "productId" TEXT NOT NULL,
+    "mimeType" TEXT NOT NULL,
+    "data" BYTEA NOT NULL,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ProductImage_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "ProductImage_productId_sortOrder_idx" ON "ProductImage"("productId", "sortOrder");
+
+ALTER TABLE "ProductImage"
+  ADD CONSTRAINT "ProductImage_productId_fkey"
+  FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20251004000009_account_profile_overhaul/migration.sql
+++ b/prisma/migrations/20251004000009_account_profile_overhaul/migration.sql
@@ -1,0 +1,41 @@
+-- Add storeName column to users
+ALTER TABLE "User" ADD COLUMN "storeName" TEXT;
+
+-- Create enum for profile change field if not exists
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'ProfileChangeField') THEN
+    CREATE TYPE "ProfileChangeField" AS ENUM ('STORE_NAME', 'EMAIL');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'ProfileChangeStatus') THEN
+    CREATE TYPE "ProfileChangeStatus" AS ENUM ('PENDING', 'APPROVED', 'REJECTED');
+  END IF;
+END$$;
+
+-- Create table for profile change requests
+CREATE TABLE IF NOT EXISTS "ProfileChangeRequest" (
+  "id" TEXT PRIMARY KEY,
+  "userId" TEXT NOT NULL,
+  "field" "ProfileChangeField" NOT NULL,
+  "newValue" TEXT NOT NULL,
+  "status" "ProfileChangeStatus" NOT NULL DEFAULT 'PENDING',
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "resolvedAt" TIMESTAMP(3),
+  "resolvedById" TEXT,
+  CONSTRAINT "ProfileChangeRequest_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "ProfileChangeRequest_resolvedById_fkey" FOREIGN KEY ("resolvedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS "ProfileChangeRequest_userId_idx" ON "ProfileChangeRequest" ("userId");
+CREATE INDEX IF NOT EXISTS "ProfileChangeRequest_status_idx" ON "ProfileChangeRequest" ("status");
+
+-- Create table for user avatars
+CREATE TABLE IF NOT EXISTS "UserAvatar" (
+  "userId" TEXT PRIMARY KEY,
+  "mimeType" TEXT NOT NULL,
+  "data" BYTEA NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "UserAvatar_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,6 +15,8 @@ model User {
   slug         String   @unique
   isAdmin      Boolean  @default(false)
   createdAt    DateTime @default(now())
+  avatarUrl    String?
+  storeName    String?
   storeBadge   StoreBadge @default(BASIC)
   storeIsOnline Boolean   @default(true)
   storeFollowers Int      @default(0)
@@ -26,6 +28,9 @@ model User {
   orderItems   OrderItem[] @relation("SellerItems")
   warehouses   Warehouse[]
   passwordResetTokens PasswordResetToken[]
+  profileChangeRequests ProfileChangeRequest[]
+  resolvedProfileChanges ProfileChangeRequest[] @relation("ProfileChangeResolver")
+  avatar       UserAvatar?
 }
 
 model Warehouse {
@@ -57,6 +62,40 @@ model Product {
   warehouse    Warehouse? @relation(fields: [warehouseId], references: [id])
 
   orderItems   OrderItem[]
+  images       ProductImage[]
+}
+
+model ProductImage {
+  id        String   @id @default(cuid())
+  productId String
+  product   Product @relation(fields: [productId], references: [id], onDelete: Cascade)
+  mimeType  String
+  data      Bytes
+  sortOrder Int      @default(0)
+  createdAt DateTime @default(now())
+}
+
+model UserAvatar {
+  userId    String   @id
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  mimeType  String
+  data      Bytes
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model PromoBanner {
+  id          Int      @id @default(autoincrement())
+  title       String
+  description String
+  highlight   String
+  imageUrl    String
+  ctaLabel    String
+  ctaHref     String
+  sortOrder   Int      @default(0)
+  isActive    Boolean  @default(true)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 }
 
 model Order {
@@ -138,6 +177,30 @@ model PasswordResetToken {
   expiresAt DateTime
   usedAt    DateTime?
   createdAt DateTime @default(now())
+}
+
+model ProfileChangeRequest {
+  id           String               @id @default(cuid())
+  userId       String
+  user         User                 @relation(fields: [userId], references: [id], onDelete: Cascade)
+  field        ProfileChangeField
+  newValue     String
+  status       ProfileChangeStatus  @default(PENDING)
+  createdAt    DateTime             @default(now())
+  resolvedAt   DateTime?
+  resolvedById String?
+  resolvedBy   User?                @relation("ProfileChangeResolver", fields: [resolvedById], references: [id])
+}
+
+enum ProfileChangeField {
+  STORE_NAME
+  EMAIL
+}
+
+enum ProfileChangeStatus {
+  PENDING
+  APPROVED
+  REJECTED
 }
 
 model ChatThread {


### PR DESCRIPTION
## Summary
- redesign the seller "Akun Saya" dashboard with inline avatar upload, store name/email requests, and helpful status messaging
- add account APIs and database structures for user avatars plus profile change requests that funnel store name and email updates to admins for approval
- extend the admin console with pending request moderation actions, store name editing, and storefront updates that surface approved branding across the site

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68e2cb8ef6ec832094e0aedfa2faae17