### PR TITLE
Add order chat feature with admin monitoring

### DIFF
--- a/app/admin/chats/page.tsx
+++ b/app/admin/chats/page.tsx
@@ -1,0 +1,111 @@
+import { prisma } from "@/lib/prisma";
+import { getSession } from "@/lib/session";
+
+function resolveSenderLabel(sender: string, userMap: Map<string, { name: string; email: string }>, buyerLabel: string) {
+  if (sender.startsWith("seller:")) {
+    const id = sender.split(":")[1] ?? "";
+    const info = userMap.get(id);
+    return info ? `Seller • ${info.name}` : "Seller";
+  }
+  if (sender.startsWith("admin:")) {
+    const id = sender.split(":")[1] ?? "";
+    const info = userMap.get(id);
+    return info ? `Admin • ${info.name}` : "Admin";
+  }
+  return `Buyer • ${buyerLabel}`;
+}
+
+export default async function AdminChatsPage() {
+  const session = await getSession();
+  const user = session.user;
+  if (!user || !user.isAdmin) return <div>Admin only.</div>;
+
+  const threads = await prisma.chatThread.findMany({
+    orderBy: { createdAt: "desc" },
+    include: {
+      messages: { orderBy: { createdAt: "asc" } },
+    },
+  });
+
+  if (threads.length === 0) {
+    return (
+      <div>
+        <h1 className="text-2xl font-semibold mb-4">Admin: Monitor Chat</h1>
+        <div className="bg-white border rounded p-6 text-sm text-gray-500">Belum ada percakapan.</div>
+      </div>
+    );
+  }
+
+  const orderIds = threads.map((thread) => thread.orderId);
+  const sellerAndAdminIds = Array.from(
+    new Set(
+      threads
+        .flatMap((thread) =>
+          thread.messages
+            .map((message) => message.sender)
+            .filter((sender) => sender.startsWith("seller:") || sender.startsWith("admin:"))
+            .map((sender) => sender.split(":")[1] ?? ""),
+        )
+        .filter((id): id is string => Boolean(id)),
+    ),
+  );
+
+  const [orders, relatedUsers] = await Promise.all([
+    prisma.order.findMany({
+      where: { id: { in: orderIds } },
+      select: { id: true, orderCode: true, buyerName: true, buyerPhone: true },
+    }),
+    prisma.user.findMany({
+      where: {
+        id: { in: sellerAndAdminIds },
+      },
+      select: { id: true, name: true, email: true },
+    }),
+  ]);
+
+  const orderMap = new Map(orders.map((order) => [order.id, order]));
+  const userMap = new Map(relatedUsers.map((item) => [item.id, { name: item.name, email: item.email }]));
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-semibold">Admin: Monitor Chat</h1>
+      {threads.map((thread) => {
+        const order = orderMap.get(thread.orderId);
+        const buyerLabel = [order?.buyerName?.trim(), order?.buyerPhone?.trim()].filter(Boolean).join(" • ") || "-";
+
+        return (
+          <div key={thread.id} className="rounded border bg-white p-4">
+            <div className="flex flex-wrap items-center justify-between gap-2 border-b pb-2 text-sm text-gray-600">
+              <div>
+                <div className="font-semibold text-gray-900">Order #{order?.orderCode ?? thread.orderId}</div>
+                <div className="text-xs text-gray-500">{buyerLabel}</div>
+              </div>
+              {order?.orderCode ? (
+                <a className="link text-xs" href={`/order/${order.orderCode}`} target="_blank" rel="noreferrer">
+                  Lihat detail pesanan
+                </a>
+              ) : null}
+            </div>
+            <div className="mt-3 space-y-2">
+              {thread.messages.length === 0 ? (
+                <div className="text-xs text-gray-500">Belum ada pesan.</div>
+              ) : (
+                thread.messages.map((message) => (
+                  <div key={message.id} className="rounded border bg-gray-50 p-3 text-xs">
+                    <div className="mb-1 font-semibold text-gray-700">
+                      {resolveSenderLabel(message.sender, userMap, buyerLabel)}
+                      <span className="ml-2 font-normal text-gray-400">
+                        {new Date(message.createdAt).toLocaleString("id-ID")}
+                      </span>
+                    </div>
+                    <div className="text-gray-800">{message.content}</div>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/api/chat/messages/[code]/route.ts
+++ b/app/api/chat/messages/[code]/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getIronSession } from "iron-session";
+
+import { prisma } from "@/lib/prisma";
+import { sessionOptions, SessionUser } from "@/lib/session";
+
+async function getOrderByCode(orderCode: string) {
+  return prisma.order.findUnique({
+    where: { orderCode },
+    include: { items: { select: { sellerId: true } } },
+  });
+}
+
+async function ensureThread(orderId: string) {
+  return prisma.chatThread.upsert({
+    where: { orderId },
+    create: { orderId },
+    update: {},
+  });
+}
+
+function serializeMessages(messages: { id: string; sender: string; content: string | null; createdAt: Date }[]) {
+  return messages.map((message) => ({
+    id: message.id,
+    sender: message.sender,
+    content: message.content,
+    createdAt: message.createdAt.toISOString(),
+  }));
+}
+
+export async function GET(_req: NextRequest, { params }: { params: { code: string } }) {
+  const order = await getOrderByCode(params.code);
+  if (!order) {
+    return NextResponse.json({ error: "Order not found" }, { status: 404 });
+  }
+
+  const thread = await ensureThread(order.id);
+  const messages = await prisma.chatMessage.findMany({
+    where: { threadId: thread.id },
+    orderBy: { createdAt: "asc" },
+  });
+
+  return NextResponse.json({ messages: serializeMessages(messages) });
+}
+
+export async function POST(req: NextRequest, { params }: { params: { code: string } }) {
+  const session = await getIronSession<{ user?: SessionUser }>(req, new Response(), sessionOptions);
+  const user = session.user;
+
+  const body = await req.json().catch(() => null);
+  const content = typeof body?.content === "string" ? body.content.trim() : "";
+  if (!content) {
+    return NextResponse.json({ error: "Pesan tidak boleh kosong" }, { status: 400 });
+  }
+
+  const order = await getOrderByCode(params.code);
+  if (!order) {
+    return NextResponse.json({ error: "Order not found" }, { status: 404 });
+  }
+
+  const sellerIds = new Set(order.items.map((item) => item.sellerId));
+
+  let sender: string;
+  if (user && sellerIds.has(user.id)) {
+    sender = `seller:${user.id}`;
+  } else if (user && user.isAdmin) {
+    sender = `admin:${user.id}`;
+  } else {
+    const buyerIdentifier = order.buyerPhone?.trim() || order.buyerName?.trim() || "anonymous";
+    sender = `buyer:${buyerIdentifier}`;
+  }
+
+  const thread = await ensureThread(order.id);
+  const message = await prisma.chatMessage.create({
+    data: {
+      threadId: thread.id,
+      sender,
+      content,
+    },
+  });
+
+  return NextResponse.json({ message: serializeMessages([message])[0] });
+}

--- a/app/order/[code]/page.tsx
+++ b/app/order/[code]/page.tsx
@@ -1,5 +1,6 @@
 // app/order/[code]/page.tsx
 import { prisma } from "@/lib/prisma";
+import OrderChat from "@/components/OrderChat";
 export const dynamic = "force-dynamic";
 
 export default async function Page({ params }: { params: { code: string } }) {
@@ -30,8 +31,10 @@ export default async function Page({ params }: { params: { code: string } }) {
         </form>
       </div>
 
-      {/* (opsional) Chat */}
-      {/* <OrderChat orderCode={params.code} role="buyer" /> */}
+      <div className="bg-white border rounded p-4">
+        <h2 className="font-semibold mb-2">Chat dengan Seller</h2>
+        <OrderChat orderCode={params.code} role="buyer" />
+      </div>
     </div>
   );
 }

--- a/app/seller/orders/[code]/page.tsx
+++ b/app/seller/orders/[code]/page.tsx
@@ -1,0 +1,47 @@
+import OrderChat from "@/components/OrderChat";
+import { prisma } from "@/lib/prisma";
+import { getSession } from "@/lib/session";
+
+export default async function SellerOrderChat({ params }: { params: { code: string } }) {
+  const session = await getSession();
+  const user = session.user;
+  if (!user) return <div>Harap login.</div>;
+
+  const order = await prisma.order.findUnique({
+    where: { orderCode: params.code },
+    include: {
+      items: {
+        where: { sellerId: user.id },
+        include: { product: true },
+      },
+    },
+  });
+
+  if (!order || order.items.length === 0) {
+    return <div>Pesanan tidak ditemukan atau tidak terkait dengan toko Anda.</div>;
+  }
+
+  const buyerInfo = [order.buyerName?.trim(), order.buyerPhone?.trim()].filter(Boolean).join(" • ");
+
+  return (
+    <div className="space-y-6">
+      <div className="bg-white border rounded p-4">
+        <h1 className="text-xl font-semibold">Pesanan #{order.orderCode}</h1>
+        <div className="mt-2 text-sm text-gray-600">{buyerInfo || "Data pembeli tidak tersedia"}</div>
+        <div className="mt-4 space-y-2">
+          {order.items.map((item) => (
+            <div key={item.id} className="rounded border p-3 text-sm">
+              <div className="font-medium">{item.product.title}</div>
+              <div className="text-gray-500">Qty: {item.qty} • Rp {new Intl.NumberFormat("id-ID").format(item.price)}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="bg-white border rounded p-4">
+        <h2 className="font-semibold mb-2">Chat dengan Pembeli</h2>
+        <OrderChat orderCode={params.code} role="seller" />
+      </div>
+    </div>
+  );
+}

--- a/app/seller/orders/page.tsx
+++ b/app/seller/orders/page.tsx
@@ -54,7 +54,12 @@ export default async function SellerOrders() {
                       ))}
                     </div>
                   </td>
-                  <td className="py-2 align-top"><a className="link" href={`/order/${o.orderCode}`} target="_blank">Detail</a></td>
+                  <td className="py-2 align-top">
+                    <div className="flex flex-col gap-1">
+                      <a className="link" href={`/order/${o.orderCode}`} target="_blank">Detail</a>
+                      <a className="link" href={`/seller/orders/${o.orderCode}`}>Chat</a>
+                    </div>
+                  </td>
                 </tr>
               );
             })}


### PR DESCRIPTION
## Summary
- add API endpoint to load and send messages for order chats
- surface the chat UI on buyer and seller order pages
- provide an admin dashboard page to monitor conversations

## Testing
- npx tsc --noEmit *(fails: existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e2fb37fe04832092858e8def6aafa3