### PR TITLE
Fix admin voucher management page runtime errors

### DIFF
--- a/app/admin/banners/page.tsx
+++ b/app/admin/banners/page.tsx
@@ -38,6 +38,9 @@ export default async function AdminBannersPage({
           <Link className="link" href="/admin/products">
             Kelola Produk
           </Link>
+          <Link className="link" href="/admin/vouchers">
+            Kelola Voucher
+          </Link>
         </div>
       </div>
 

--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -11,6 +11,20 @@ export default async function AdminOrders() {
   return (
     <div>
       <h1 className="text-2xl font-semibold mb-4">Admin: Semua Pesanan</h1>
+      <div className="mb-4 flex flex-wrap gap-3 text-sm">
+        <a className="link" href="/admin/users">
+          Manajemen Pengguna
+        </a>
+        <a className="link" href="/admin/products">
+          Kelola Produk Seller
+        </a>
+        <a className="link" href="/admin/banners">
+          Kelola Banner Promo
+        </a>
+        <a className="link" href="/admin/vouchers">
+          Kelola Voucher Publik
+        </a>
+      </div>
       <div className="bg-white border rounded p-4">
         <table className="w-full text-sm">
           <thead><tr className="text-left border-b"><th className="py-2">Tanggal</th><th>Kode</th><th>Status</th><th>Metode</th><th>Barang</th><th>Ongkir</th><th>Nominal</th><th>Aksi</th></tr></thead>

--- a/app/admin/products/page.tsx
+++ b/app/admin/products/page.tsx
@@ -49,6 +49,9 @@ export default async function AdminProductsPage({
           <Link className="link" href="/admin/banners">
             Kelola Banner Promo
           </Link>
+          <Link className="link" href="/admin/vouchers">
+            Kelola Voucher Publik
+          </Link>
           <Link className="link" href="/admin/users">
             &larr; Kembali ke pengguna
           </Link>

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -48,6 +48,9 @@ export default async function AdminUsersPage({
         <Link className="link" href="/admin/banners">
           Kelola Banner Promo
         </Link>
+        <Link className="link" href="/admin/vouchers">
+          Kelola Voucher Publik
+        </Link>
         <Link className="link" href="/admin/orders">
           Pantau Pesanan
         </Link>
@@ -69,6 +72,7 @@ export default async function AdminUsersPage({
               <th className="py-2">Nama</th>
               <th>Email</th>
               <th>Peran</th>
+              <th>Status</th>
               <th>Toko</th>
               <th>Produk</th>
               <th>Penjualan</th>
@@ -80,6 +84,7 @@ export default async function AdminUsersPage({
               const isCurrent = user.id === currentUser.id;
               const hasWarehouse = user.warehouses.length > 0;
               const isSeller = user._count.products > 0 || hasWarehouse;
+              const isBanned = user.isBanned;
               return (
                 <tr key={user.id} id={`user-${user.id}`} className="border-b align-top">
                   <td className="py-3">
@@ -105,11 +110,16 @@ export default async function AdminUsersPage({
                     </div>
                   </td>
                   <td className="py-3">{user.email}</td>
-                  <td className="py-3">
-                    <span className={`badge ${user.isAdmin ? "badge-paid" : "badge-pending"}`}>
-                      {user.isAdmin ? "ADMIN" : "USER"}
-                    </span>
-                  </td>
+                <td className="py-3">
+                  <span className={`badge ${user.isAdmin ? "badge-paid" : "badge-pending"}`}>
+                    {user.isAdmin ? "ADMIN" : "USER"}
+                  </span>
+                </td>
+                <td className="py-3">
+                  <span className={`badge ${isBanned ? "badge-danger" : "badge-paid"}`}>
+                    {isBanned ? "Diblokir" : "Aktif"}
+                  </span>
+                </td>
                   <td className="py-3">
                     {isSeller ? (
                       <div className="space-y-1">
@@ -183,6 +193,28 @@ export default async function AdminUsersPage({
                         title={isCurrent ? "Tidak dapat mengubah status admin sendiri" : undefined}
                       >
                         {user.isAdmin ? "Cabut Admin" : "Jadikan Admin"}
+                      </button>
+                    </form>
+                    <form
+                      method="POST"
+                      action={`/api/admin/users/${user.id}/toggle-ban`}
+                      className="inline"
+                    >
+                      <button
+                        className={`text-xs font-semibold text-white rounded px-3 py-1 ${
+                          isBanned
+                            ? "bg-emerald-600 hover:bg-emerald-700"
+                            : "bg-red-600 hover:bg-red-700"
+                        } disabled:cursor-not-allowed disabled:bg-gray-300`}
+                        type="submit"
+                        disabled={isCurrent}
+                        title={
+                          isCurrent
+                            ? "Tidak dapat mengubah status ban sendiri"
+                            : undefined
+                        }
+                      >
+                        {isBanned ? "Cabut Ban" : "Ban Pengguna"}
                       </button>
                     </form>
                     {isSeller ? (

--- a/app/admin/vouchers/page.tsx
+++ b/app/admin/vouchers/page.tsx
@@ -1,0 +1,250 @@
+import Link from "next/link";
+
+import { prisma } from "@/lib/prisma";
+import { getSession } from "@/lib/session";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function toDateTimeLocal(value: Date | null) {
+  if (!value) return "";
+  const iso = value.toISOString();
+  return iso.slice(0, 16);
+}
+
+export default async function AdminVouchersPage({
+  searchParams,
+}: {
+  searchParams?: Record<string, string | string[] | undefined>;
+}) {
+  const session = await getSession();
+  const currentUser = session.user;
+
+  if (!currentUser || !currentUser.isAdmin) {
+    return <div>Admin only.</div>;
+  }
+
+  const voucherKinds = ["PERCENT", "FIXED"] as const;
+
+  let vouchers: Awaited<ReturnType<typeof prisma.voucher.findMany>> = [];
+  let loadError: string | undefined;
+  try {
+    vouchers = await prisma.voucher.findMany({
+      orderBy: [{ createdAt: "desc" }, { code: "asc" }],
+    });
+  } catch (error) {
+    console.error("Failed to load vouchers", error);
+    loadError = "Tidak dapat memuat data voucher. Silakan coba lagi.";
+  }
+
+  const successMessage =
+    typeof searchParams?.message === "string" ? searchParams.message : undefined;
+  const errorMessage =
+    typeof searchParams?.error === "string" ? searchParams.error : undefined;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h1 className="text-2xl font-semibold">Admin: Kelola Voucher Publik</h1>
+        <div className="flex flex-wrap gap-3 text-sm">
+          <Link className="link" href="/admin/users">
+            Manajemen Pengguna
+          </Link>
+          <Link className="link" href="/admin/products">
+            Kelola Produk
+          </Link>
+          <Link className="link" href="/admin/banners">
+            Kelola Banner Promo
+          </Link>
+          <Link className="link" href="/admin/orders">
+            Pantau Pesanan
+          </Link>
+        </div>
+      </div>
+
+      {successMessage ? (
+        <div className="rounded border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700">
+          {successMessage}
+        </div>
+      ) : null}
+      {errorMessage ? (
+        <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+          {errorMessage}
+        </div>
+      ) : null}
+
+      <section className="rounded border bg-white p-4">
+        <h2 className="text-lg font-semibold">Tambah Voucher Baru</h2>
+        <p className="mt-1 text-sm text-gray-500">
+          Voucher aktif akan dapat digunakan oleh pembeli di halaman checkout publik.
+        </p>
+        <form className="mt-4 grid gap-4 md:grid-cols-2" method="POST" action="/api/admin/vouchers/create">
+          <label className="flex flex-col text-sm">
+            <span className="font-medium">Kode Voucher</span>
+            <input
+              className="rounded border px-3 py-2 uppercase"
+              name="code"
+              placeholder="contoh: AKAY20"
+              required
+            />
+          </label>
+          <label className="flex flex-col text-sm">
+            <span className="font-medium">Jenis</span>
+            <select className="rounded border px-3 py-2" name="kind" defaultValue="PERCENT">
+              {voucherKinds.map((kind) => (
+                <option key={kind} value={kind}>
+                  {kind === "PERCENT" ? "Persentase" : "Potongan Tetap"}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col text-sm">
+            <span className="font-medium">Nilai</span>
+            <input
+              className="rounded border px-3 py-2"
+              type="number"
+              name="value"
+              min="1"
+              placeholder="Contoh: 10"
+              required
+            />
+            <span className="mt-1 text-xs text-gray-500">
+              Jika jenis Persentase, masukkan nilai 1-100. Jika jenis Tetap, isi nominal rupiah.
+            </span>
+          </label>
+          <label className="flex flex-col text-sm">
+            <span className="font-medium">Minimal Belanja</span>
+            <input
+              className="rounded border px-3 py-2"
+              type="number"
+              name="minSpend"
+              min="0"
+              defaultValue={0}
+            />
+          </label>
+          <label className="flex flex-col text-sm">
+            <span className="font-medium">Berlaku Hingga</span>
+            <input className="rounded border px-3 py-2" type="datetime-local" name="expiresAt" />
+            <span className="mt-1 text-xs text-gray-500">
+              Kosongkan bila voucher tidak memiliki tanggal kedaluwarsa.
+            </span>
+          </label>
+          <label className="flex items-center gap-2 text-sm">
+            <input className="h-4 w-4" type="checkbox" name="active" defaultChecked />
+            <span>Aktifkan voucher ini</span>
+          </label>
+          <div className="md:col-span-2">
+            <button className="btn-outline" type="submit">
+              Simpan Voucher
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold">Daftar Voucher</h2>
+        {loadError ? (
+          <div className="rounded border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+            {loadError}
+          </div>
+        ) : vouchers.length === 0 ? (
+          <div className="rounded border border-dashed border-gray-300 bg-white p-8 text-center text-sm text-gray-500">
+            Belum ada voucher yang tersimpan.
+          </div>
+        ) : (
+          <div className="grid gap-4">
+            {vouchers.map((voucher) => (
+              <div key={voucher.id} className="rounded border bg-white p-4 shadow-sm">
+                <form
+                  className="grid gap-4 md:grid-cols-2"
+                  method="POST"
+                  action={`/api/admin/vouchers/${voucher.id}/update`}
+                >
+                  <label className="flex flex-col text-sm">
+                    <span className="font-medium">Kode Voucher</span>
+                    <input
+                      className="rounded border px-3 py-2 uppercase"
+                      name="code"
+                      defaultValue={voucher.code}
+                      required
+                    />
+                  </label>
+                  <label className="flex flex-col text-sm">
+                    <span className="font-medium">Jenis</span>
+                    <select className="rounded border px-3 py-2" name="kind" defaultValue={voucher.kind}>
+                      {voucherKinds.map((kind) => (
+                        <option key={kind} value={kind}>
+                          {kind === "PERCENT" ? "Persentase" : "Potongan Tetap"}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <label className="flex flex-col text-sm">
+                    <span className="font-medium">Nilai</span>
+                    <input
+                      className="rounded border px-3 py-2"
+                      type="number"
+                      name="value"
+                      min="1"
+                      defaultValue={voucher.value}
+                    />
+                  </label>
+                  <label className="flex flex-col text-sm">
+                    <span className="font-medium">Minimal Belanja</span>
+                    <input
+                      className="rounded border px-3 py-2"
+                      type="number"
+                      name="minSpend"
+                      min="0"
+                      defaultValue={voucher.minSpend}
+                    />
+                  </label>
+                  <label className="flex flex-col text-sm">
+                    <span className="font-medium">Berlaku Hingga</span>
+                    <input
+                      className="rounded border px-3 py-2"
+                      type="datetime-local"
+                      name="expiresAt"
+                      defaultValue={toDateTimeLocal(voucher.expiresAt)}
+                    />
+                  </label>
+                  <label className="flex items-center gap-2 text-sm">
+                    <input className="h-4 w-4" type="checkbox" name="active" defaultChecked={voucher.active} />
+                    <span>Voucher aktif</span>
+                  </label>
+                  <div className="md:col-span-2 flex flex-wrap items-center gap-3">
+                    <button className="btn-outline" type="submit">
+                      Perbarui Voucher
+                    </button>
+                    <span className="text-xs text-gray-500">
+                      Dibuat: {voucher.createdAt.toLocaleString("id-ID")}
+                    </span>
+                    {voucher.expiresAt ? (
+                      <span className="text-xs text-gray-500">
+                        Berlaku hingga: {voucher.expiresAt.toLocaleString("id-ID")}
+                      </span>
+                    ) : (
+                      <span className="text-xs text-gray-400">Tanpa kedaluwarsa</span>
+                    )}
+                  </div>
+                </form>
+                <form
+                  className="mt-3 inline-block"
+                  method="POST"
+                  action={`/api/admin/vouchers/${voucher.id}/delete`}
+                >
+                  <button
+                    className="rounded bg-red-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-red-700"
+                    type="submit"
+                  >
+                    Hapus Voucher
+                  </button>
+                </form>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/app/api/admin/users/[id]/toggle-ban/route.ts
+++ b/app/api/admin/users/[id]/toggle-ban/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getIronSession } from "iron-session";
+
+import { prisma } from "@/lib/prisma";
+import { sessionOptions, type SessionUser } from "@/lib/session";
+
+export const runtime = "nodejs";
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const res = new NextResponse();
+  const session = await getIronSession<{ user?: SessionUser }>(req, res, sessionOptions);
+  const actor = session.user;
+
+  if (!actor || !actor.isAdmin) {
+    return NextResponse.json({ error: "Admin only" }, { status: 403 });
+  }
+
+  if (params.id === actor.id) {
+    const redirectUrl = new URL("/admin/users", req.url);
+    redirectUrl.searchParams.set(
+      "error",
+      "Tidak dapat mengubah status ban pada akun sendiri",
+    );
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  const target = await prisma.user.findUnique({ where: { id: params.id } });
+  if (!target) {
+    const redirectUrl = new URL("/admin/users", req.url);
+    redirectUrl.searchParams.set("error", "Pengguna tidak ditemukan");
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  await prisma.user.update({
+    where: { id: params.id },
+    data: { isBanned: !target.isBanned },
+  });
+
+  const redirectUrl = new URL("/admin/users", req.url);
+  redirectUrl.searchParams.set(
+    "message",
+    target.isBanned ? "Pengguna berhasil dipulihkan" : "Pengguna berhasil diblokir",
+  );
+  return NextResponse.redirect(redirectUrl);
+}

--- a/app/api/admin/vouchers/[id]/delete/route.ts
+++ b/app/api/admin/vouchers/[id]/delete/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getIronSession } from "iron-session";
+import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
+
+import { prisma } from "@/lib/prisma";
+import { sessionOptions, type SessionUser } from "@/lib/session";
+
+export const runtime = "nodejs";
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const res = new NextResponse();
+  const session = await getIronSession<{ user?: SessionUser }>(req, res, sessionOptions);
+  const actor = session.user;
+
+  if (!actor || !actor.isAdmin) {
+    return NextResponse.json({ error: "Admin only" }, { status: 403 });
+  }
+
+  try {
+    await prisma.voucher.delete({ where: { id: params.id } });
+    const redirectUrl = new URL("/admin/vouchers", req.url);
+    redirectUrl.searchParams.set("message", "Voucher berhasil dihapus");
+    return NextResponse.redirect(redirectUrl);
+  } catch (error) {
+    const redirectUrl = new URL("/admin/vouchers", req.url);
+    if (error instanceof PrismaClientKnownRequestError && error.code === "P2025") {
+      redirectUrl.searchParams.set("error", "Voucher tidak ditemukan");
+    } else {
+      redirectUrl.searchParams.set("error", "Gagal menghapus voucher");
+    }
+    return NextResponse.redirect(redirectUrl);
+  }
+}

--- a/app/api/admin/vouchers/[id]/update/route.ts
+++ b/app/api/admin/vouchers/[id]/update/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getIronSession } from "iron-session";
+import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
+import { VoucherKind } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { sessionOptions, type SessionUser } from "@/lib/session";
+
+export const runtime = "nodejs";
+
+function parseBoolean(value: FormDataEntryValue | null) {
+  return value === "on" || value === "true";
+}
+
+function parseDate(value: FormDataEntryValue | null) {
+  if (typeof value !== "string" || value.trim() === "") {
+    return null;
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error("Tanggal kedaluwarsa tidak valid");
+  }
+  return parsed;
+}
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const res = new NextResponse();
+  const session = await getIronSession<{ user?: SessionUser }>(req, res, sessionOptions);
+  const actor = session.user;
+
+  if (!actor || !actor.isAdmin) {
+    return NextResponse.json({ error: "Admin only" }, { status: 403 });
+  }
+
+  const form = await req.formData();
+
+  const codeRaw = form.get("code");
+  const kindRaw = form.get("kind");
+  const valueRaw = form.get("value");
+  const minSpendRaw = form.get("minSpend");
+
+  try {
+    if (typeof codeRaw !== "string" || codeRaw.trim().length === 0) {
+      throw new Error("Kode voucher wajib diisi");
+    }
+    const code = codeRaw.trim().toUpperCase();
+
+    if (typeof kindRaw !== "string" || !Object.values(VoucherKind).includes(kindRaw as VoucherKind)) {
+      throw new Error("Jenis voucher tidak valid");
+    }
+    const kind = kindRaw as VoucherKind;
+
+    const value = Number.parseInt(String(valueRaw ?? ""), 10);
+    if (!Number.isFinite(value) || value <= 0) {
+      throw new Error("Nilai voucher harus berupa angka positif");
+    }
+    if (kind === "PERCENT" && (value < 1 || value > 100)) {
+      throw new Error("Nilai persentase harus antara 1 hingga 100");
+    }
+
+    const minSpend = Number.parseInt(String(minSpendRaw ?? "0"), 10);
+    if (!Number.isFinite(minSpend) || minSpend < 0) {
+      throw new Error("Minimal belanja tidak valid");
+    }
+
+    const expiresAt = parseDate(form.get("expiresAt"));
+    const active = parseBoolean(form.get("active"));
+
+    await prisma.voucher.update({
+      where: { id: params.id },
+      data: {
+        code,
+        kind,
+        value,
+        minSpend,
+        expiresAt,
+        active,
+      },
+    });
+
+    const redirectUrl = new URL("/admin/vouchers", req.url);
+    redirectUrl.searchParams.set("message", "Voucher berhasil diperbarui");
+    return NextResponse.redirect(redirectUrl);
+  } catch (error) {
+    let message = "Gagal memperbarui voucher";
+    if (error instanceof PrismaClientKnownRequestError && error.code === "P2025") {
+      message = "Voucher tidak ditemukan";
+    } else if (error instanceof Error) {
+      message = error.message;
+    }
+    const redirectUrl = new URL("/admin/vouchers", req.url);
+    redirectUrl.searchParams.set("error", message);
+    return NextResponse.redirect(redirectUrl);
+  }
+}

--- a/app/api/admin/vouchers/create/route.ts
+++ b/app/api/admin/vouchers/create/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getIronSession } from "iron-session";
+import { VoucherKind } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { sessionOptions, type SessionUser } from "@/lib/session";
+
+export const runtime = "nodejs";
+
+function parseBoolean(value: FormDataEntryValue | null) {
+  return value === "on" || value === "true";
+}
+
+function parseDate(value: FormDataEntryValue | null) {
+  if (typeof value !== "string" || value.trim() === "") {
+    return null;
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error("Tanggal kedaluwarsa tidak valid");
+  }
+  return parsed;
+}
+
+export async function POST(req: NextRequest) {
+  const res = new NextResponse();
+  const session = await getIronSession<{ user?: SessionUser }>(req, res, sessionOptions);
+  const actor = session.user;
+
+  if (!actor || !actor.isAdmin) {
+    return NextResponse.json({ error: "Admin only" }, { status: 403 });
+  }
+
+  const form = await req.formData();
+
+  const codeRaw = form.get("code");
+  const kindRaw = form.get("kind");
+  const valueRaw = form.get("value");
+  const minSpendRaw = form.get("minSpend");
+
+  try {
+    if (typeof codeRaw !== "string" || codeRaw.trim().length === 0) {
+      throw new Error("Kode voucher wajib diisi");
+    }
+    const code = codeRaw.trim().toUpperCase();
+
+    if (typeof kindRaw !== "string" || !Object.values(VoucherKind).includes(kindRaw as VoucherKind)) {
+      throw new Error("Jenis voucher tidak valid");
+    }
+    const kind = kindRaw as VoucherKind;
+
+    const value = Number.parseInt(String(valueRaw ?? ""), 10);
+    if (!Number.isFinite(value) || value <= 0) {
+      throw new Error("Nilai voucher harus berupa angka positif");
+    }
+    if (kind === "PERCENT" && (value < 1 || value > 100)) {
+      throw new Error("Nilai persentase harus antara 1 hingga 100");
+    }
+
+    const minSpend = Number.parseInt(String(minSpendRaw ?? "0"), 10);
+    if (!Number.isFinite(minSpend) || minSpend < 0) {
+      throw new Error("Minimal belanja tidak valid");
+    }
+
+    const expiresAt = parseDate(form.get("expiresAt"));
+    const active = parseBoolean(form.get("active"));
+
+    await prisma.voucher.create({
+      data: {
+        code,
+        kind,
+        value,
+        minSpend,
+        expiresAt,
+        active,
+      },
+    });
+
+    const redirectUrl = new URL("/admin/vouchers", req.url);
+    redirectUrl.searchParams.set("message", "Voucher baru berhasil dibuat");
+    return NextResponse.redirect(redirectUrl);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Terjadi kesalahan saat membuat voucher";
+    const redirectUrl = new URL("/admin/vouchers", req.url);
+    redirectUrl.searchParams.set("error", message);
+    return NextResponse.redirect(redirectUrl);
+  }
+}

--- a/app/api/auth/google/callback/shared.ts
+++ b/app/api/auth/google/callback/shared.ts
@@ -136,6 +136,12 @@ export async function handleGoogleCallback(req: NextRequest): Promise<NextRespon
     });
   }
 
+  if (user.isBanned) {
+    return clearStateCookie(
+      NextResponse.redirect(new URL("/seller/login?error=banned", url.origin)),
+    );
+  }
+
   const redirectTo = new URL("/seller/dashboard", url.origin);
   const response = clearStateCookie(NextResponse.redirect(redirectTo));
 

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -14,6 +14,10 @@ export async function POST(req: NextRequest) {
   const ok = await bcrypt.compare(password, user.passwordHash);
   if (!ok) return NextResponse.json({ error: 'Invalid' }, { status: 400 });
 
+  if (user.isBanned) {
+    return NextResponse.redirect(new URL('/seller/login?error=banned', req.url));
+  }
+
   const redirectTo = new URL('/seller/dashboard', req.url);
   const res = new NextResponse();
   const session = await getIronSession<{ user?: SessionUser }>(req, res, sessionOptions);

--- a/app/api/seller/item-status/route.ts
+++ b/app/api/seller/item-status/route.ts
@@ -16,6 +16,11 @@ export async function POST(req: NextRequest) {
   const user = session.user as SessionUser | undefined;
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
+  const account = await prisma.user.findUnique({ where: { id: user.id }, select: { isBanned: true } });
+  if (!account || account.isBanned) {
+    return NextResponse.redirect(new URL('/seller/login?error=banned', req.url));
+  }
+
   const item = await prisma.orderItem.findUnique({ where: { id: orderItemId }, include: { order: true } });
   if (!item || item.sellerId !== user.id || item.order.orderCode !== orderCode) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 

--- a/app/api/seller/products/create/route.ts
+++ b/app/api/seller/products/create/route.ts
@@ -67,6 +67,11 @@ export async function POST(req: NextRequest) {
   const user = session.user as SessionUser | undefined;
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
+  const account = await prisma.user.findUnique({ where: { id: user.id }, select: { isBanned: true } });
+  if (!account || account.isBanned) {
+    return NextResponse.redirect(new URL('/seller/login?error=banned', req.url));
+  }
+
   const finalOriginalPrice = originalPrice && originalPrice > price ? originalPrice : null;
 
   const files = form

--- a/app/api/seller/products/delete/[id]/route.ts
+++ b/app/api/seller/products/delete/[id]/route.ts
@@ -11,6 +11,11 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
   const user = session.user as SessionUser | undefined;
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
+  const account = await prisma.user.findUnique({ where: { id: user.id }, select: { isBanned: true } });
+  if (!account || account.isBanned) {
+    return NextResponse.redirect(new URL('/seller/login?error=banned', req.url));
+  }
+
   const prod = await prisma.product.findUnique({ where: { id: params.id } });
   if (!prod || prod.sellerId !== user.id) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 

--- a/app/api/seller/products/update/[id]/route.ts
+++ b/app/api/seller/products/update/[id]/route.ts
@@ -13,6 +13,11 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
   const user = session.user as SessionUser | undefined;
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
+  const account = await prisma.user.findUnique({ where: { id: user.id }, select: { isBanned: true } });
+  if (!account || account.isBanned) {
+    return NextResponse.redirect(new URL('/seller/login?error=banned', req.url));
+  }
+
   const prod = await prisma.product.findUnique({ where: { id: params.id } });
   if (!prod || prod.sellerId !== user.id) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 

--- a/app/api/seller/returns/[id]/update/route.ts
+++ b/app/api/seller/returns/[id]/update/route.ts
@@ -13,6 +13,11 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
   const user = session.user as SessionUser | undefined;
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
+  const account = await prisma.user.findUnique({ where: { id: user.id }, select: { isBanned: true } });
+  if (!account || account.isBanned) {
+    return NextResponse.redirect(new URL('/seller/login?error=banned', req.url));
+  }
+
   const rr = await prisma.returnRequest.findUnique({ where: { id: params.id }, include: { orderItem: true } });
   if (!rr || rr.orderItem.sellerId !== user.id) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 

--- a/app/api/seller/warehouses/create/route.ts
+++ b/app/api/seller/warehouses/create/route.ts
@@ -14,6 +14,11 @@ export async function POST(req: NextRequest) {
   const user = session.user as SessionUser | undefined;
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
+  const account = await prisma.user.findUnique({ where: { id: user.id }, select: { isBanned: true } });
+  if (!account || account.isBanned) {
+    return NextResponse.redirect(new URL('/seller/login?error=banned', req.url));
+  }
+
   await prisma.warehouse.create({ data: { ownerId: user.id, name, city: city || null } });
   return NextResponse.redirect(new URL('/seller/warehouses', req.url));
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -5,6 +5,7 @@
 .badge{ @apply inline-block text-xs px-2 py-0.5 rounded-full; }
 .badge-pending{ @apply bg-amber-100 text-amber-700; }
 .badge-paid{ @apply bg-emerald-100 text-emerald-700; }
+.badge-danger{ @apply bg-red-100 text-red-700; }
 .badge-packed{ @apply bg-blue-100 text-blue-700; }
 .badge-shipped{ @apply bg-purple-100 text-purple-700; }
 .badge-delivered{ @apply bg-green-100 text-green-700; }

--- a/app/seller/dashboard/page.tsx
+++ b/app/seller/dashboard/page.tsx
@@ -6,6 +6,28 @@ export default async function Dashboard() {
   const user = session.user;
   if (!user) return <div>Harap login sebagai seller.</div>;
 
+  const account = await prisma.user.findUnique({
+    where: { id: user.id },
+    select: { isBanned: true },
+  });
+
+  if (!account || account.isBanned) {
+    return (
+      <div>
+        <h1 className="text-2xl font-semibold mb-4">Dashboard Seller</h1>
+        <div className="rounded border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          Akun seller Anda telah diblokir oleh tim admin karena pelanggaran. Hubungi
+          {" "}
+          <a className="underline" href="mailto:support@akay.id">
+            support@akay.id
+          </a>
+          {" "}
+          untuk proses banding atau informasi lebih lanjut.
+        </div>
+      </div>
+    );
+  }
+
   const [pcount, orders, revenue] = await Promise.all([
     prisma.product.count({ where: { sellerId: user.id } }),
     prisma.orderItem.findMany({ where: { sellerId: user.id }, select: { orderId: true }, distinct: ["orderId"] }),

--- a/app/seller/login/page.tsx
+++ b/app/seller/login/page.tsx
@@ -2,11 +2,25 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/session";
 
-export default async function SellerLogin() {
+export default async function SellerLogin({
+  searchParams,
+}: {
+  searchParams?: Record<string, string | string[] | undefined>;
+}) {
   const session = await getSession();
 
   if (session.user) {
     redirect("/seller/dashboard");
+  }
+
+  const errorParam =
+    typeof searchParams?.error === "string" ? searchParams.error : undefined;
+  let errorMessage: string | undefined;
+  if (errorParam === "banned") {
+    errorMessage =
+      "Akun Anda telah diblokir oleh admin. Silakan hubungi support@akay.id untuk informasi lebih lanjut.";
+  } else if (errorParam) {
+    errorMessage = "Gagal masuk. Silakan coba lagi atau reset password Anda.";
   }
 
   return (
@@ -59,6 +73,11 @@ export default async function SellerLogin() {
             <h1 className="text-2xl font-semibold text-gray-900">Log in ke akun seller</h1>
             <p className="mt-2 text-sm text-gray-500">Masuk untuk mengelola toko dan menerima pesanan terbaru Anda.</p>
 
+            {errorMessage ? (
+              <div className="mt-6 rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+                {errorMessage}
+              </div>
+            ) : null}
             <form method="POST" action="/api/auth/login" className="mt-6 space-y-4">
               <div className="space-y-1">
                 <label htmlFor="email" className="text-sm font-medium text-gray-700">

--- a/app/seller/orders/page.tsx
+++ b/app/seller/orders/page.tsx
@@ -6,6 +6,28 @@ export default async function SellerOrders() {
   const user = session.user;
   if (!user) return <div>Harap login.</div>;
 
+  const account = await prisma.user.findUnique({
+    where: { id: user.id },
+    select: { isBanned: true },
+  });
+
+  if (!account || account.isBanned) {
+    return (
+      <div>
+        <h1 className="text-2xl font-semibold mb-4">Pesanan (Produk Saya)</h1>
+        <div className="rounded border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          Anda tidak dapat mengelola pesanan karena akun sedang diblokir. Hubungi
+          {" "}
+          <a className="underline" href="mailto:support@akay.id">
+            support@akay.id
+          </a>
+          {" "}
+          untuk klarifikasi lebih lanjut.
+        </div>
+      </div>
+    );
+  }
+
   const orders = await prisma.order.findMany({
     orderBy: { createdAt: 'desc' },
     where: { items: { some: { sellerId: user.id } } },

--- a/app/seller/products/page.tsx
+++ b/app/seller/products/page.tsx
@@ -9,6 +9,28 @@ export default async function SellerProducts() {
   const user = session.user;
   if (!user) return <div>Harap login.</div>;
 
+  const account = await prisma.user.findUnique({
+    where: { id: user.id },
+    select: { isBanned: true },
+  });
+
+  if (!account || account.isBanned) {
+    return (
+      <div>
+        <h1 className="text-2xl font-semibold mb-4">Produk Saya</h1>
+        <div className="rounded border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          Akun Anda sedang diblokir sehingga tidak dapat mengelola produk. Hubungi
+          {" "}
+          <a className="underline" href="mailto:support@akay.id">
+            support@akay.id
+          </a>
+          {" "}
+          untuk bantuan lebih lanjut.
+        </div>
+      </div>
+    );
+  }
+
   const [products, warehouses] = await Promise.all([
     prisma.product.findMany({ where: { sellerId: user.id }, orderBy: { createdAt: 'desc' }, include: { warehouse: true } }),
     prisma.warehouse.findMany({ where: { ownerId: user.id }, orderBy: { createdAt: 'desc' } })

--- a/app/seller/returns/page.tsx
+++ b/app/seller/returns/page.tsx
@@ -6,6 +6,28 @@ export default async function SellerReturns() {
   const user = session.user;
   if (!user) return <div>Harap login.</div>;
 
+  const account = await prisma.user.findUnique({
+    where: { id: user.id },
+    select: { isBanned: true },
+  });
+
+  if (!account || account.isBanned) {
+    return (
+      <div>
+        <h1 className="text-2xl font-semibold mb-4">Retur Masuk</h1>
+        <div className="rounded border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          Anda tidak dapat memproses retur selama akun diblokir. Silakan hubungi
+          {" "}
+          <a className="underline" href="mailto:support@akay.id">
+            support@akay.id
+          </a>
+          {" "}
+          untuk peninjauan akun.
+        </div>
+      </div>
+    );
+  }
+
   const returns = await prisma.returnRequest.findMany({
     orderBy: { createdAt: 'desc' },
     where: { orderItem: { sellerId: user.id } },

--- a/app/seller/warehouses/page.tsx
+++ b/app/seller/warehouses/page.tsx
@@ -6,6 +6,28 @@ export default async function Warehouses() {
   const user = session.user;
   if (!user) return <div>Harap login.</div>;
 
+  const account = await prisma.user.findUnique({
+    where: { id: user.id },
+    select: { isBanned: true },
+  });
+
+  if (!account || account.isBanned) {
+    return (
+      <div>
+        <h1 className="text-2xl font-semibold mb-4">Gudang</h1>
+        <div className="rounded border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          Tidak dapat mengelola gudang karena akun diblokir. Hubungi
+          {" "}
+          <a className="underline" href="mailto:support@akay.id">
+            support@akay.id
+          </a>
+          {" "}
+          untuk mengaktifkan kembali akses Anda.
+        </div>
+      </div>
+    );
+  }
+
   const warehouses = await prisma.warehouse.findMany({ where: { ownerId: user.id }, orderBy: { createdAt: 'desc' } });
 
   return (

--- a/prisma/migrations/20251004000009_add_midtrans_order_metadata/migration.sql
+++ b/prisma/migrations/20251004000009_add_midtrans_order_metadata/migration.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "Order"
+  ADD COLUMN "midtransTransactionId" TEXT,
+  ADD COLUMN "midtransOrderId" TEXT,
+  ADD COLUMN "midtransStatus" TEXT,
+  ADD COLUMN "midtransPaymentType" TEXT,
+  ADD COLUMN "midtransFraudStatus" TEXT;

--- a/prisma/migrations/20251004000010_add_user_ban_flag/migration.sql
+++ b/prisma/migrations/20251004000010_add_user_ban_flag/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "User"
+  ADD COLUMN "isBanned" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,6 +14,7 @@ model User {
   passwordHash String
   slug         String   @unique
   isAdmin      Boolean  @default(false)
+  isBanned     Boolean  @default(false)
   createdAt    DateTime @default(now())
   avatarUrl    String?
   storeBadge   StoreBadge @default(BASIC)
@@ -102,6 +103,11 @@ model Order {
   voucherDiscount  Int           @default(0)
   proofImage       Bytes?
   proofMimeType    String?
+  midtransTransactionId String?
+  midtransOrderId       String?
+  midtransStatus        String?
+  midtransPaymentType   String?
+  midtransFraudStatus   String?
   createdAt        DateTime      @default(now())
 
   items            OrderItem[]


### PR DESCRIPTION
## Summary
- ensure the admin vouchers page always renders by forcing the Node runtime, handling Prisma failures gracefully, and guarding with a friendlier error message
- align voucher API handlers and the ban toggle endpoint with the Node runtime so Prisma access remains stable in production

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68e341621fac8320bf50bbcc42ad206d