### PR TITLE
Store buyer email on orders and load related items

### DIFF
--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { COURIERS } from "@/lib/shipping";
 import { getSession } from "@/lib/session";
 import { calculateFlashSalePrice } from "@/lib/flash-sale";
+import { sendOrderCreatedEmail } from "@/lib/email";
 
 export const runtime = "nodejs";
 
@@ -87,7 +88,7 @@ export async function POST(req: NextRequest) {
   const order = await prisma.order.create({
     data: {
       orderCode,
-      buyerName, buyerPhone, buyerAddress,
+      buyerName, buyerPhone, buyerAddress, buyerEmail,
       buyerId,
       courier: courier.label,
       shippingCost,

--- a/app/api/seller/item-status/route.ts
+++ b/app/api/seller/item-status/route.ts
@@ -29,7 +29,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.redirect(new URL('/seller/onboarding', req.url));
   }
 
-  const item = await prisma.orderItem.findUnique({ where: { id: orderItemId }, include: { order: true } });
+  const item = await prisma.orderItem.findUnique({ where: { id: orderItemId }, include: { order: { include: { items: true } } } });
   if (!item || item.sellerId !== user.id || item.order.orderCode !== orderCode) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
   if (item.status === status) {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -120,6 +120,7 @@ model Order {
   buyerName        String
   buyerPhone       String
   buyerAddress     String
+  buyerEmail       String?
   buyerId          String?
   buyer            User?         @relation("BuyerOrders", fields: [buyerId], references: [id])
   courier          String


### PR DESCRIPTION
## Summary
- add a buyerEmail column to orders so related flows can reference the contact email
- populate the stored email during checkout and import the order confirmation mail helper
- ensure seller item status updates include order items when deciding whether to send notifications

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4f12844888320bea172b5108fc06c