### PR TITLE
Add buyer account profile and address management

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -1,0 +1,386 @@
+import { redirect } from "next/navigation";
+
+import { prisma } from "@/lib/prisma";
+import { getSession } from "@/lib/session";
+import type { Gender } from "@prisma/client";
+
+export const dynamic = "force-dynamic";
+
+const GENDER_OPTIONS: { value: "" | Gender; label: string }[] = [
+  { value: "", label: "Pilih jenis kelamin" },
+  { value: "MALE", label: "Laki-laki" },
+  { value: "FEMALE", label: "Perempuan" },
+  { value: "OTHER", label: "Lainnya" },
+];
+
+type AccountPageProps = {
+  searchParams?: Record<string, string | string[] | undefined>;
+};
+
+export default async function AccountPage({ searchParams }: AccountPageProps) {
+  const session = await getSession();
+  const viewer = session.user;
+
+  if (!viewer) {
+    redirect("/seller/login");
+  }
+
+  const account = await prisma.user.findUnique({
+    where: { id: viewer.id },
+    select: {
+      name: true,
+      email: true,
+      username: true,
+      avatarUrl: true,
+      phoneNumber: true,
+      gender: true,
+      addresses: {
+        orderBy: { createdAt: "desc" },
+        select: {
+          id: true,
+          fullName: true,
+          phoneNumber: true,
+          province: true,
+          city: true,
+          district: true,
+          postalCode: true,
+          addressLine: true,
+          additionalInfo: true,
+          createdAt: true,
+        },
+      },
+    },
+  });
+
+  if (!account) {
+    redirect("/seller/login");
+  }
+
+  const profileError = typeof searchParams?.profileError === "string" ? searchParams.profileError : null;
+  const profileUpdated = searchParams?.profileUpdated === "1";
+  const addressError = typeof searchParams?.addressError === "string" ? searchParams.addressError : null;
+  const addressAdded = searchParams?.addressAdded === "1";
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-8 px-4 py-8">
+      <header className="space-y-1">
+        <h1 className="text-3xl font-semibold text-gray-900">Akun Saya</h1>
+        <p className="text-sm text-gray-600">Kelola informasi profil dan alamat pengiriman Anda.</p>
+      </header>
+
+      <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-gray-900">Profil</h2>
+            <p className="text-sm text-gray-600">Perbarui informasi dasar akun pembeli Anda.</p>
+          </div>
+          <div className="flex items-center gap-3">
+            <div className="relative h-16 w-16 overflow-hidden rounded-full border border-gray-200 bg-gray-100">
+              {account.avatarUrl?.trim() ? (
+                <img
+                  src={account.avatarUrl}
+                  alt={account.name}
+                  className="h-full w-full object-cover"
+                />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center text-2xl font-semibold text-gray-500">
+                  {account.name.charAt(0).toUpperCase()}
+                </div>
+              )}
+            </div>
+            <div className="text-sm text-gray-600">
+              <p className="font-medium text-gray-900">{account.name}</p>
+              <p>{account.email}</p>
+            </div>
+          </div>
+        </div>
+
+        {profileError ? (
+          <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {profileError}
+          </div>
+        ) : null}
+
+        {profileUpdated ? (
+          <div className="mb-4 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+            Profil berhasil diperbarui.
+          </div>
+        ) : null}
+
+        <form method="POST" action="/api/account/profile" className="grid gap-4 md:grid-cols-2">
+          <input type="hidden" name="redirectTo" value="/account" />
+
+          <div className="space-y-1">
+            <label htmlFor="avatarUrl" className="text-sm font-medium text-gray-700">
+              Foto profil (URL)
+            </label>
+            <input
+              id="avatarUrl"
+              name="avatarUrl"
+              type="url"
+              placeholder="https://contoh.com/foto.jpg"
+              defaultValue={account.avatarUrl ?? ""}
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+            />
+            <p className="text-xs text-gray-500">Gunakan tautan gambar langsung berformat http atau https.</p>
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="username" className="text-sm font-medium text-gray-700">
+              Username
+            </label>
+            <input
+              id="username"
+              name="username"
+              type="text"
+              placeholder="nama-pengguna"
+              minLength={3}
+              defaultValue={account.username ?? ""}
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+            />
+            <p className="text-xs text-gray-500">Username digunakan untuk identitas publik di masa mendatang.</p>
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="name" className="text-sm font-medium text-gray-700">
+              Nama lengkap
+            </label>
+            <input
+              id="name"
+              name="name"
+              type="text"
+              required
+              minLength={3}
+              defaultValue={account.name}
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="email" className="text-sm font-medium text-gray-700">
+              Email
+            </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              required
+              defaultValue={account.email}
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="phoneNumber" className="text-sm font-medium text-gray-700">
+              Nomor telepon
+            </label>
+            <input
+              id="phoneNumber"
+              name="phoneNumber"
+              type="tel"
+              inputMode="tel"
+              placeholder="08xxxxxxxxxx"
+              defaultValue={account.phoneNumber ?? ""}
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+            />
+            <p className="text-xs text-gray-500">Masukkan nomor aktif untuk memudahkan konfirmasi pesanan.</p>
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="gender" className="text-sm font-medium text-gray-700">
+              Jenis kelamin
+            </label>
+            <select
+              id="gender"
+              name="gender"
+              defaultValue={(account.gender as Gender | null) ?? ""}
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+            >
+              {GENDER_OPTIONS.map((option) => (
+                <option key={option.value || "empty"} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="md:col-span-2 flex items-center justify-end gap-3 pt-2">
+            <button type="submit" className="btn-primary">
+              Simpan Perubahan
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-gray-900">Alamat Pengiriman</h2>
+            <p className="text-sm text-gray-600">Tambahkan alamat baru untuk mempercepat proses checkout.</p>
+          </div>
+        </div>
+
+        {addressError ? (
+          <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {addressError}
+          </div>
+        ) : null}
+
+        {addressAdded ? (
+          <div className="mb-4 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+            Alamat baru berhasil ditambahkan.
+          </div>
+        ) : null}
+
+        <div className="mb-6 grid gap-4 md:grid-cols-2">
+          {account.addresses.length === 0 ? (
+            <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 p-6 text-sm text-gray-600">
+              Belum ada alamat tersimpan. Tambahkan alamat pertama Anda melalui formulir di bawah.
+            </div>
+          ) : (
+            account.addresses.map((address) => (
+              <div key={address.id} className="rounded-xl border border-gray-200 p-5 shadow-sm">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-semibold text-gray-900">{address.fullName}</p>
+                    <p className="text-xs text-gray-500">{address.phoneNumber}</p>
+                  </div>
+                  <span className="text-xs text-gray-400">
+                    {new Intl.DateTimeFormat("id-ID", {
+                      dateStyle: "medium",
+                    }).format(new Date(address.createdAt))}
+                  </span>
+                </div>
+                <div className="mt-3 space-y-1 text-sm text-gray-600">
+                  <p>
+                    {address.addressLine}
+                    {address.additionalInfo ? `, ${address.additionalInfo}` : ""}
+                  </p>
+                  <p>
+                    {address.district}, {address.city}, {address.province} {address.postalCode}
+                  </p>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+
+        <form method="POST" action="/api/account/addresses" className="grid gap-4 md:grid-cols-2">
+          <input type="hidden" name="redirectTo" value="/account" />
+
+          <div className="space-y-1">
+            <label htmlFor="fullName" className="text-sm font-medium text-gray-700">
+              Nama Lengkap
+            </label>
+            <input
+              id="fullName"
+              name="fullName"
+              type="text"
+              required
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="phoneNumberAddress" className="text-sm font-medium text-gray-700">
+              Nomor Telepon
+            </label>
+            <input
+              id="phoneNumberAddress"
+              name="phoneNumber"
+              type="tel"
+              inputMode="tel"
+              required
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="province" className="text-sm font-medium text-gray-700">
+              Provinsi
+            </label>
+            <input
+              id="province"
+              name="province"
+              type="text"
+              required
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="city" className="text-sm font-medium text-gray-700">
+              Kota / Kabupaten
+            </label>
+            <input
+              id="city"
+              name="city"
+              type="text"
+              required
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="district" className="text-sm font-medium text-gray-700">
+              Kecamatan
+            </label>
+            <input
+              id="district"
+              name="district"
+              type="text"
+              required
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="postalCode" className="text-sm font-medium text-gray-700">
+              Kode Pos
+            </label>
+            <input
+              id="postalCode"
+              name="postalCode"
+              type="text"
+              required
+              pattern="\d{4,10}"
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+            />
+          </div>
+
+          <div className="space-y-1 md:col-span-2">
+            <label htmlFor="addressLine" className="text-sm font-medium text-gray-700">
+              Alamat Lengkap
+            </label>
+            <textarea
+              id="addressLine"
+              name="addressLine"
+              required
+              rows={3}
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+            />
+          </div>
+
+          <div className="space-y-1 md:col-span-2">
+            <label htmlFor="additionalInfo" className="text-sm font-medium text-gray-700">
+              Detail Lainnya (opsional)
+            </label>
+            <textarea
+              id="additionalInfo"
+              name="additionalInfo"
+              rows={2}
+              placeholder="Contoh: Patokan rumah warna hijau, blok B nomor 3"
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+            />
+          </div>
+
+          <div className="md:col-span-2 flex items-center justify-end gap-3 pt-2">
+            <button type="submit" className="btn-primary">
+              Simpan Alamat
+            </button>
+          </div>
+        </form>
+      </section>
+    </div>
+  );
+}

--- a/app/api/account/addresses/route.ts
+++ b/app/api/account/addresses/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { getSession } from "@/lib/session";
+
+export const runtime = "nodejs";
+
+function resolveRedirect(redirectTo: FormDataEntryValue | null, reqUrl: string, fallback: string) {
+  const base = new URL(reqUrl);
+  if (typeof redirectTo !== "string" || redirectTo.trim().length === 0) {
+    return new URL(fallback, base);
+  }
+
+  try {
+    const target = new URL(redirectTo, base);
+    if (target.origin !== base.origin) {
+      return new URL(fallback, base);
+    }
+    return target;
+  } catch {
+    return new URL(fallback, base);
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const session = await getSession();
+  const actor = session.user;
+
+  const form = await req.formData();
+  const redirectUrl = resolveRedirect(form.get("redirectTo"), req.url, "/account");
+
+  if (!actor) {
+    return NextResponse.redirect(new URL("/seller/login", req.url));
+  }
+
+  const fullNameRaw = form.get("fullName");
+  const phoneRaw = form.get("phoneNumber");
+  const provinceRaw = form.get("province");
+  const cityRaw = form.get("city");
+  const districtRaw = form.get("district");
+  const postalCodeRaw = form.get("postalCode");
+  const addressLineRaw = form.get("addressLine");
+  const additionalRaw = form.get("additionalInfo");
+
+  const fullName = typeof fullNameRaw === "string" ? fullNameRaw.trim() : "";
+  const phoneNumber = typeof phoneRaw === "string" ? phoneRaw.trim() : "";
+  const province = typeof provinceRaw === "string" ? provinceRaw.trim() : "";
+  const city = typeof cityRaw === "string" ? cityRaw.trim() : "";
+  const district = typeof districtRaw === "string" ? districtRaw.trim() : "";
+  const postalCode = typeof postalCodeRaw === "string" ? postalCodeRaw.trim() : "";
+  const addressLine = typeof addressLineRaw === "string" ? addressLineRaw.trim() : "";
+  const additionalInfo = typeof additionalRaw === "string" ? additionalRaw.trim() : "";
+
+  const requiredFields: [string, string][] = [
+    ["Nama Lengkap", fullName],
+    ["Nomor telepon", phoneNumber],
+    ["Provinsi", province],
+    ["Kota", city],
+    ["Kecamatan", district],
+    ["Kode pos", postalCode],
+    ["Alamat lengkap", addressLine],
+  ];
+
+  for (const [label, value] of requiredFields) {
+    if (!value) {
+      redirectUrl.searchParams.set(
+        "addressError",
+        `${label} wajib diisi.`,
+      );
+      redirectUrl.searchParams.delete("addressAdded");
+      return NextResponse.redirect(redirectUrl);
+    }
+  }
+
+  if (!/^\d{4,10}$/.test(postalCode)) {
+    redirectUrl.searchParams.set("addressError", "Kode pos harus berupa 4-10 digit angka.");
+    redirectUrl.searchParams.delete("addressAdded");
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  if (phoneNumber && !/^\+?\d{6,15}$/.test(phoneNumber)) {
+    redirectUrl.searchParams.set("addressError", "Nomor telepon tidak valid.");
+    redirectUrl.searchParams.delete("addressAdded");
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  try {
+    await prisma.userAddress.create({
+      data: {
+        userId: actor.id,
+        fullName,
+        phoneNumber,
+        province,
+        city,
+        district,
+        postalCode,
+        addressLine,
+        additionalInfo: additionalInfo || null,
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Gagal menambahkan alamat.";
+    redirectUrl.searchParams.set("addressError", message);
+    redirectUrl.searchParams.delete("addressAdded");
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  redirectUrl.searchParams.delete("addressError");
+  redirectUrl.searchParams.set("addressAdded", "1");
+
+  return NextResponse.redirect(redirectUrl);
+}

--- a/app/api/account/profile/route.ts
+++ b/app/api/account/profile/route.ts
@@ -1,0 +1,175 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getIronSession } from "iron-session";
+import { Prisma } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { sessionOptions, type SessionUser } from "@/lib/session";
+
+export const runtime = "nodejs";
+
+function resolveRedirect(redirectTo: FormDataEntryValue | null, reqUrl: string, fallback: string) {
+  const base = new URL(reqUrl);
+  if (typeof redirectTo !== "string" || redirectTo.trim().length === 0) {
+    return new URL(fallback, base);
+  }
+
+  try {
+    const target = new URL(redirectTo, base);
+    if (target.origin !== base.origin) {
+      return new URL(fallback, base);
+    }
+    return target;
+  } catch {
+    return new URL(fallback, base);
+  }
+}
+
+function mergeSessionCookies(source: NextResponse, target: NextResponse) {
+  source.headers.forEach((value, key) => {
+    if (key.toLowerCase() === "set-cookie") {
+      target.headers.append(key, value);
+    }
+  });
+  return target;
+}
+
+function validateEmail(value: string) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+function normalizeUsername(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  return trimmed.toLowerCase();
+}
+
+function sanitizeAvatarUrl(value: string) {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    if (!["http:", "https:"].includes(parsed.protocol)) {
+      throw new Error("URL harus menggunakan protokol http atau https");
+    }
+    return trimmed;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "URL foto profil tidak valid";
+    throw new Error(message);
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const res = new NextResponse();
+  const session = await getIronSession<{ user?: SessionUser }>(req, res, sessionOptions);
+  const actor = session.user;
+
+  const form = await req.formData();
+  const redirectUrl = resolveRedirect(form.get("redirectTo"), req.url, "/account");
+
+  if (!actor) {
+    return NextResponse.redirect(new URL("/seller/login", req.url));
+  }
+
+  const nameRaw = form.get("name");
+  const emailRaw = form.get("email");
+  const usernameRaw = form.get("username");
+  const phoneRaw = form.get("phoneNumber");
+  const genderRaw = form.get("gender");
+  const avatarRaw = form.get("avatarUrl");
+
+  const name = typeof nameRaw === "string" ? nameRaw.trim() : "";
+  const email = typeof emailRaw === "string" ? emailRaw.trim().toLowerCase() : "";
+  const usernameNormalized = typeof usernameRaw === "string" ? normalizeUsername(usernameRaw) : "";
+  const phoneNumber = typeof phoneRaw === "string" ? phoneRaw.trim() : "";
+  const gender = typeof genderRaw === "string" && genderRaw ? genderRaw : "";
+
+  let avatarUrl: string | null = null;
+
+  try {
+    if (typeof avatarRaw === "string") {
+      avatarUrl = sanitizeAvatarUrl(avatarRaw);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "URL foto profil tidak valid";
+    redirectUrl.searchParams.set("profileError", message);
+    redirectUrl.searchParams.delete("profileUpdated");
+    const response = NextResponse.redirect(redirectUrl);
+    return mergeSessionCookies(res, response);
+  }
+
+  if (!name) {
+    redirectUrl.searchParams.set("profileError", "Nama wajib diisi.");
+    redirectUrl.searchParams.delete("profileUpdated");
+    const response = NextResponse.redirect(redirectUrl);
+    return mergeSessionCookies(res, response);
+  }
+
+  if (!email || !validateEmail(email)) {
+    redirectUrl.searchParams.set("profileError", "Email tidak valid.");
+    redirectUrl.searchParams.delete("profileUpdated");
+    const response = NextResponse.redirect(redirectUrl);
+    return mergeSessionCookies(res, response);
+  }
+
+  if (usernameNormalized && usernameNormalized.length < 3) {
+    redirectUrl.searchParams.set("profileError", "Username minimal 3 karakter.");
+    redirectUrl.searchParams.delete("profileUpdated");
+    const response = NextResponse.redirect(redirectUrl);
+    return mergeSessionCookies(res, response);
+  }
+
+  if (phoneNumber && phoneNumber.length < 6) {
+    redirectUrl.searchParams.set("profileError", "Nomor telepon minimal 6 digit.");
+    redirectUrl.searchParams.delete("profileUpdated");
+    const response = NextResponse.redirect(redirectUrl);
+    return mergeSessionCookies(res, response);
+  }
+
+  const allowedGenders = ["MALE", "FEMALE", "OTHER"] as const;
+  let genderValue: typeof allowedGenders[number] | null = null;
+  if (gender) {
+    if (!allowedGenders.includes(gender as (typeof allowedGenders)[number])) {
+      redirectUrl.searchParams.set("profileError", "Jenis kelamin tidak valid.");
+      redirectUrl.searchParams.delete("profileUpdated");
+      const response = NextResponse.redirect(redirectUrl);
+      return mergeSessionCookies(res, response);
+    }
+    genderValue = gender as (typeof allowedGenders)[number];
+  }
+
+  try {
+    await prisma.user.update({
+      where: { id: actor.id },
+      data: {
+        name,
+        email,
+        username: usernameNormalized ? usernameNormalized : null,
+        phoneNumber: phoneNumber || null,
+        gender: genderValue ?? null,
+        avatarUrl,
+      },
+    });
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+      redirectUrl.searchParams.set("profileError", "Username sudah digunakan.");
+    } else {
+      const message = error instanceof Error ? error.message : "Gagal memperbarui profil.";
+      redirectUrl.searchParams.set("profileError", message);
+    }
+    redirectUrl.searchParams.delete("profileUpdated");
+    const response = NextResponse.redirect(redirectUrl);
+    return mergeSessionCookies(res, response);
+  }
+
+  session.user = { ...actor, name, email };
+  await session.save();
+
+  redirectUrl.searchParams.delete("profileError");
+  redirectUrl.searchParams.set("profileUpdated", "1");
+
+  const response = NextResponse.redirect(redirectUrl);
+  return mergeSessionCookies(res, response);
+}

--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { COURIERS } from "@/lib/shipping";
 import { getSession } from "@/lib/session";
 import { calculateFlashSalePrice } from "@/lib/flash-sale";
+import { sendOrderCreatedEmail } from "@/lib/email";
 
 export const runtime = "nodejs";
 
@@ -87,7 +88,7 @@ export async function POST(req: NextRequest) {
   const order = await prisma.order.create({
     data: {
       orderCode,
-      buyerName, buyerPhone, buyerAddress,
+      buyerName, buyerPhone, buyerAddress, buyerEmail,
       buyerId,
       courier: courier.label,
       shippingCost,

--- a/app/api/seller/item-status/route.ts
+++ b/app/api/seller/item-status/route.ts
@@ -29,7 +29,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.redirect(new URL('/seller/onboarding', req.url));
   }
 
-  const item = await prisma.orderItem.findUnique({ where: { id: orderItemId }, include: { order: true } });
+  const item = await prisma.orderItem.findUnique({ where: { id: orderItemId }, include: { order: { include: { items: true } } } });
   if (!item || item.sellerId !== user.id || item.order.orderCode !== orderCode) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
   if (item.status === status) {

--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -77,7 +77,7 @@ export function SiteHeader({ user }: SiteHeaderProps) {
                 {open && (
                   <div className="absolute right-0 z-50 mt-2 w-48 overflow-hidden rounded-md bg-white text-gray-700 shadow-lg">
                     <Link
-                      href="/seller/dashboard"
+                      href="/account"
                       className="block px-4 py-3 text-sm font-medium hover:bg-gray-100"
                       onClick={() => setOpen(false)}
                     >

--- a/prisma/migrations/20251004000015_add_buyer_account_profile/migration.sql
+++ b/prisma/migrations/20251004000015_add_buyer_account_profile/migration.sql
@@ -1,0 +1,37 @@
+-- CreateEnum
+CREATE TYPE "Gender" AS ENUM ('MALE', 'FEMALE', 'OTHER');
+
+-- AlterTable
+ALTER TABLE "User"
+  ADD COLUMN "username" TEXT,
+  ADD COLUMN "phoneNumber" TEXT,
+  ADD COLUMN "gender" "Gender";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_username_key" ON "User"("username");
+
+-- CreateTable
+CREATE TABLE "UserAddress" (
+  "id" TEXT PRIMARY KEY,
+  "userId" TEXT NOT NULL,
+  "fullName" TEXT NOT NULL,
+  "phoneNumber" TEXT NOT NULL,
+  "province" TEXT NOT NULL,
+  "city" TEXT NOT NULL,
+  "district" TEXT NOT NULL,
+  "postalCode" TEXT NOT NULL,
+  "addressLine" TEXT NOT NULL,
+  "additionalInfo" TEXT,
+  "isDefault" BOOLEAN NOT NULL DEFAULT FALSE,
+  "createdAt" TIMESTAMP NOT NULL DEFAULT NOW(),
+  "updatedAt" TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- AddForeignKey
+ALTER TABLE "UserAddress"
+  ADD CONSTRAINT "UserAddress_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "User"("id")
+  ON UPDATE CASCADE ON DELETE CASCADE;
+
+-- CreateIndex
+CREATE INDEX "UserAddress_userId_idx" ON "UserAddress"("userId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,6 +18,9 @@ model User {
   sellerOnboardingStatus SellerOnboardingStatus @default(ACTIVE)
   createdAt    DateTime @default(now())
   avatarUrl    String?
+  username     String?  @unique
+  phoneNumber  String?
+  gender       Gender?
   storeBadge   StoreBadge @default(BASIC)
   storeIsOnline Boolean   @default(true)
   storeFollowers Int      @default(0)
@@ -33,6 +36,7 @@ model User {
   warehouses   Warehouse[]
   flashSales   FlashSale[]
   passwordResetTokens PasswordResetToken[]
+  addresses    UserAddress[]
 }
 
 enum SellerOnboardingStatus {
@@ -72,6 +76,12 @@ model Product {
   orderItems   OrderItem[]
   images       ProductImage[]
   flashSales   FlashSale[]
+}
+
+enum Gender {
+  MALE
+  FEMALE
+  OTHER
 }
 
 model FlashSale {
@@ -120,6 +130,7 @@ model Order {
   buyerName        String
   buyerPhone       String
   buyerAddress     String
+  buyerEmail       String?
   buyerId          String?
   buyer            User?         @relation("BuyerOrders", fields: [buyerId], references: [id])
   courier          String
@@ -144,6 +155,25 @@ model Order {
   logs             VerificationLog[]
   returns          ReturnRequest[]
   review           OrderReview?
+}
+
+model UserAddress {
+  id            String   @id @default(cuid())
+  userId        String
+  user          User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  fullName      String
+  phoneNumber   String
+  province      String
+  city          String
+  district      String
+  postalCode    String
+  addressLine   String
+  additionalInfo String?
+  isDefault     Boolean  @default(false)
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  @@index([userId])
 }
 
 model OrderReview {


### PR DESCRIPTION
## Summary
- add a dedicated Akun Saya page so buyers can update profile details and manage shipping addresses
- expose profile and address API endpoints with validation that persist new user fields and refresh the session state
- extend the Prisma schema with buyer profile fields and address storage while updating the header shortcut to point to the new page

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4f12844888320bea172b5108fc06c