### PR TITLE
Allow checkout to reuse saved buyer address

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -1,0 +1,386 @@
+import { redirect } from "next/navigation";
+
+import { prisma } from "@/lib/prisma";
+import { getSession } from "@/lib/session";
+import type { Gender } from "@prisma/client";
+
+export const dynamic = "force-dynamic";
+
+const GENDER_OPTIONS: { value: "" | Gender; label: string }[] = [
+  { value: "", label: "Pilih jenis kelamin" },
+  { value: "MALE", label: "Laki-laki" },
+  { value: "FEMALE", label: "Perempuan" },
+  { value: "OTHER", label: "Lainnya" },
+];
+
+type AccountPageProps = {
+  searchParams?: Record<string, string | string[] | undefined>;
+};
+
+export default async function AccountPage({ searchParams }: AccountPageProps) {
+  const session = await getSession();
+  const viewer = session.user;
+
+  if (!viewer) {
+    redirect("/seller/login");
+  }
+
+  const account = await prisma.user.findUnique({
+    where: { id: viewer.id },
+    select: {
+      name: true,
+      email: true,
+      username: true,
+      avatarUrl: true,
+      phoneNumber: true,
+      gender: true,
+      addresses: {
+        orderBy: { createdAt: "desc" },
+        select: {
+          id: true,
+          fullName: true,
+          phoneNumber: true,
+          province: true,
+          city: true,
+          district: true,
+          postalCode: true,
+          addressLine: true,
+          additionalInfo: true,
+          createdAt: true,
+        },
+      },
+    },
+  });
+
+  if (!account) {
+    redirect("/seller/login");
+  }
+
+  const profileError = typeof searchParams?.profileError === "string" ? searchParams.profileError : null;
+  const profileUpdated = searchParams?.profileUpdated === "1";
+  const addressError = typeof searchParams?.addressError === "string" ? searchParams.addressError : null;
+  const addressAdded = searchParams?.addressAdded === "1";
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-8 px-4 py-8">
+      <header className="space-y-1">
+        <h1 className="text-3xl font-semibold text-gray-900">Akun Saya</h1>
+        <p className="text-sm text-gray-600">Kelola informasi profil dan alamat pengiriman Anda.</p>
+      </header>
+
+      <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-gray-900">Profil</h2>
+            <p className="text-sm text-gray-600">Perbarui informasi dasar akun pembeli Anda.</p>
+          </div>
+          <div className="flex items-center gap-3">
+            <div className="relative h-16 w-16 overflow-hidden rounded-full border border-gray-200 bg-gray-100">
+              {account.avatarUrl?.trim() ? (
+                <img
+                  src={account.avatarUrl}
+                  alt={account.name}
+                  className="h-full w-full object-cover"
+                />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center text-2xl font-semibold text-gray-500">
+                  {account.name.charAt(0).toUpperCase()}
+                </div>
+              )}
+            </div>
+            <div className="text-sm text-gray-600">
+              <p className="font-medium text-gray-900">{account.name}</p>
+              <p>{account.email}</p>
+            </div>
+          </div>
+        </div>
+
+        {profileError ? (
+          <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {profileError}
+          </div>
+        ) : null}
+
+        {profileUpdated ? (
+          <div className="mb-4 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+            Profil berhasil diperbarui.
+          </div>
+        ) : null}
+
+        <form method="POST" action="/api/account/profile" className="grid gap-4 md:grid-cols-2">
+          <input type="hidden" name="redirectTo" value="/account" />
+
+          <div className="space-y-1">
+            <label htmlFor="avatarUrl" className="text-sm font-medium text-gray-700">
+              Foto profil (URL)
+            </label>
+            <input
+              id="avatarUrl"
+              name="avatarUrl"
+              type="url"
+              placeholder="https://contoh.com/foto.jpg"
+              defaultValue={account.avatarUrl ?? ""}
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+            />
+            <p className="text-xs text-gray-500">Gunakan tautan gambar langsung berformat http atau https.</p>
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="username" className="text-sm font-medium text-gray-700">
+              Username
+            </label>
+            <input
+              id="username"
+              name="username"
+              type="text"
+              placeholder="nama-pengguna"
+              minLength={3}
+              defaultValue={account.username ?? ""}
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+            />
+            <p className="text-xs text-gray-500">Username digunakan untuk identitas publik di masa mendatang.</p>
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="name" className="text-sm font-medium text-gray-700">
+              Nama lengkap
+            </label>
+            <input
+              id="name"
+              name="name"
+              type="text"
+              required
+              minLength={3}
+              defaultValue={account.name}
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="email" className="text-sm font-medium text-gray-700">
+              Email
+            </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              required
+              defaultValue={account.email}
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="phoneNumber" className="text-sm font-medium text-gray-700">
+              Nomor telepon
+            </label>
+            <input
+              id="phoneNumber"
+              name="phoneNumber"
+              type="tel"
+              inputMode="tel"
+              placeholder="08xxxxxxxxxx"
+              defaultValue={account.phoneNumber ?? ""}
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+            />
+            <p className="text-xs text-gray-500">Masukkan nomor aktif untuk memudahkan konfirmasi pesanan.</p>
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="gender" className="text-sm font-medium text-gray-700">
+              Jenis kelamin
+            </label>
+            <select
+              id="gender"
+              name="gender"
+              defaultValue={(account.gender as Gender | null) ?? ""}
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+            >
+              {GENDER_OPTIONS.map((option) => (
+                <option key={option.value || "empty"} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="md:col-span-2 flex items-center justify-end gap-3 pt-2">
+            <button type="submit" className="btn-primary">
+              Simpan Perubahan
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-gray-900">Alamat Pengiriman</h2>
+            <p className="text-sm text-gray-600">Tambahkan alamat baru untuk mempercepat proses checkout.</p>
+          </div>
+        </div>
+
+        {addressError ? (
+          <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {addressError}
+          </div>
+        ) : null}
+
+        {addressAdded ? (
+          <div className="mb-4 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+            Alamat baru berhasil ditambahkan.
+          </div>
+        ) : null}
+
+        <div className="mb-6 grid gap-4 md:grid-cols-2">
+          {account.addresses.length === 0 ? (
+            <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 p-6 text-sm text-gray-600">
+              Belum ada alamat tersimpan. Tambahkan alamat pertama Anda melalui formulir di bawah.
+            </div>
+          ) : (
+            account.addresses.map((address) => (
+              <div key={address.id} className="rounded-xl border border-gray-200 p-5 shadow-sm">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-semibold text-gray-900">{address.fullName}</p>
+                    <p className="text-xs text-gray-500">{address.phoneNumber}</p>
+                  </div>
+                  <span className="text-xs text-gray-400">
+                    {new Intl.DateTimeFormat("id-ID", {
+                      dateStyle: "medium",
+                    }).format(new Date(address.createdAt))}
+                  </span>
+                </div>
+                <div className="mt-3 space-y-1 text-sm text-gray-600">
+                  <p>
+                    {address.addressLine}
+                    {address.additionalInfo ? `, ${address.additionalInfo}` : ""}
+                  </p>
+                  <p>
+                    {address.district}, {address.city}, {address.province} {address.postalCode}
+                  </p>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+
+        <form method="POST" action="/api/account/addresses" className="grid gap-4 md:grid-cols-2">
+          <input type="hidden" name="redirectTo" value="/account" />
+
+          <div className="space-y-1">
+            <label htmlFor="fullName" className="text-sm font-medium text-gray-700">
+              Nama Lengkap
+            </label>
+            <input
+              id="fullName"
+              name="fullName"
+              type="text"
+              required
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="phoneNumberAddress" className="text-sm font-medium text-gray-700">
+              Nomor Telepon
+            </label>
+            <input
+              id="phoneNumberAddress"
+              name="phoneNumber"
+              type="tel"
+              inputMode="tel"
+              required
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="province" className="text-sm font-medium text-gray-700">
+              Provinsi
+            </label>
+            <input
+              id="province"
+              name="province"
+              type="text"
+              required
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="city" className="text-sm font-medium text-gray-700">
+              Kota / Kabupaten
+            </label>
+            <input
+              id="city"
+              name="city"
+              type="text"
+              required
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="district" className="text-sm font-medium text-gray-700">
+              Kecamatan
+            </label>
+            <input
+              id="district"
+              name="district"
+              type="text"
+              required
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="postalCode" className="text-sm font-medium text-gray-700">
+              Kode Pos
+            </label>
+            <input
+              id="postalCode"
+              name="postalCode"
+              type="text"
+              required
+              pattern="\d{4,10}"
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+            />
+          </div>
+
+          <div className="space-y-1 md:col-span-2">
+            <label htmlFor="addressLine" className="text-sm font-medium text-gray-700">
+              Alamat Lengkap
+            </label>
+            <textarea
+              id="addressLine"
+              name="addressLine"
+              required
+              rows={3}
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+            />
+          </div>
+
+          <div className="space-y-1 md:col-span-2">
+            <label htmlFor="additionalInfo" className="text-sm font-medium text-gray-700">
+              Detail Lainnya (opsional)
+            </label>
+            <textarea
+              id="additionalInfo"
+              name="additionalInfo"
+              rows={2}
+              placeholder="Contoh: Patokan rumah warna hijau, blok B nomor 3"
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+            />
+          </div>
+
+          <div className="md:col-span-2 flex items-center justify-end gap-3 pt-2">
+            <button type="submit" className="btn-primary">
+              Simpan Alamat
+            </button>
+          </div>
+        </form>
+      </section>
+    </div>
+  );
+}

--- a/app/api/account/addresses/route.ts
+++ b/app/api/account/addresses/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { getSession } from "@/lib/session";
+
+export const runtime = "nodejs";
+
+function resolveRedirect(redirectTo: FormDataEntryValue | null, reqUrl: string, fallback: string) {
+  const base = new URL(reqUrl);
+  if (typeof redirectTo !== "string" || redirectTo.trim().length === 0) {
+    return new URL(fallback, base);
+  }
+
+  try {
+    const target = new URL(redirectTo, base);
+    if (target.origin !== base.origin) {
+      return new URL(fallback, base);
+    }
+    return target;
+  } catch {
+    return new URL(fallback, base);
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const session = await getSession();
+  const actor = session.user;
+
+  const form = await req.formData();
+  const redirectUrl = resolveRedirect(form.get("redirectTo"), req.url, "/account");
+
+  if (!actor) {
+    return NextResponse.redirect(new URL("/seller/login", req.url));
+  }
+
+  const fullNameRaw = form.get("fullName");
+  const phoneRaw = form.get("phoneNumber");
+  const provinceRaw = form.get("province");
+  const cityRaw = form.get("city");
+  const districtRaw = form.get("district");
+  const postalCodeRaw = form.get("postalCode");
+  const addressLineRaw = form.get("addressLine");
+  const additionalRaw = form.get("additionalInfo");
+
+  const fullName = typeof fullNameRaw === "string" ? fullNameRaw.trim() : "";
+  const phoneNumber = typeof phoneRaw === "string" ? phoneRaw.trim() : "";
+  const province = typeof provinceRaw === "string" ? provinceRaw.trim() : "";
+  const city = typeof cityRaw === "string" ? cityRaw.trim() : "";
+  const district = typeof districtRaw === "string" ? districtRaw.trim() : "";
+  const postalCode = typeof postalCodeRaw === "string" ? postalCodeRaw.trim() : "";
+  const addressLine = typeof addressLineRaw === "string" ? addressLineRaw.trim() : "";
+  const additionalInfo = typeof additionalRaw === "string" ? additionalRaw.trim() : "";
+
+  const requiredFields: [string, string][] = [
+    ["Nama Lengkap", fullName],
+    ["Nomor telepon", phoneNumber],
+    ["Provinsi", province],
+    ["Kota", city],
+    ["Kecamatan", district],
+    ["Kode pos", postalCode],
+    ["Alamat lengkap", addressLine],
+  ];
+
+  for (const [label, value] of requiredFields) {
+    if (!value) {
+      redirectUrl.searchParams.set(
+        "addressError",
+        `${label} wajib diisi.`,
+      );
+      redirectUrl.searchParams.delete("addressAdded");
+      return NextResponse.redirect(redirectUrl);
+    }
+  }
+
+  if (!/^\d{4,10}$/.test(postalCode)) {
+    redirectUrl.searchParams.set("addressError", "Kode pos harus berupa 4-10 digit angka.");
+    redirectUrl.searchParams.delete("addressAdded");
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  if (phoneNumber && !/^\+?\d{6,15}$/.test(phoneNumber)) {
+    redirectUrl.searchParams.set("addressError", "Nomor telepon tidak valid.");
+    redirectUrl.searchParams.delete("addressAdded");
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  try {
+    await prisma.userAddress.create({
+      data: {
+        userId: actor.id,
+        fullName,
+        phoneNumber,
+        province,
+        city,
+        district,
+        postalCode,
+        addressLine,
+        additionalInfo: additionalInfo || null,
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Gagal menambahkan alamat.";
+    redirectUrl.searchParams.set("addressError", message);
+    redirectUrl.searchParams.delete("addressAdded");
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  redirectUrl.searchParams.delete("addressError");
+  redirectUrl.searchParams.set("addressAdded", "1");
+
+  return NextResponse.redirect(redirectUrl);
+}

--- a/app/api/account/checkout-data/route.ts
+++ b/app/api/account/checkout-data/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { getSession } from "@/lib/session";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  const session = await getSession();
+  const viewer = session.user;
+
+  if (!viewer) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const account = await prisma.user.findUnique({
+    where: { id: viewer.id },
+    select: {
+      name: true,
+      email: true,
+      phoneNumber: true,
+      addresses: {
+        orderBy: [
+          { isDefault: "desc" },
+          { createdAt: "desc" },
+        ],
+        select: {
+          id: true,
+          fullName: true,
+          phoneNumber: true,
+          province: true,
+          city: true,
+          district: true,
+          postalCode: true,
+          addressLine: true,
+          additionalInfo: true,
+          isDefault: true,
+          createdAt: true,
+        },
+      },
+    },
+  });
+
+  if (!account) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const defaultAddress =
+    account.addresses.find((address) => address.isDefault) ?? account.addresses[0] ?? null;
+
+  return NextResponse.json({
+    profile: {
+      name: account.name,
+      email: account.email,
+      phoneNumber: account.phoneNumber,
+    },
+    defaultAddress,
+    addressesCount: account.addresses.length,
+  });
+}

--- a/app/api/account/profile/route.ts
+++ b/app/api/account/profile/route.ts
@@ -1,0 +1,175 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getIronSession } from "iron-session";
+import { Prisma } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { sessionOptions, type SessionUser } from "@/lib/session";
+
+export const runtime = "nodejs";
+
+function resolveRedirect(redirectTo: FormDataEntryValue | null, reqUrl: string, fallback: string) {
+  const base = new URL(reqUrl);
+  if (typeof redirectTo !== "string" || redirectTo.trim().length === 0) {
+    return new URL(fallback, base);
+  }
+
+  try {
+    const target = new URL(redirectTo, base);
+    if (target.origin !== base.origin) {
+      return new URL(fallback, base);
+    }
+    return target;
+  } catch {
+    return new URL(fallback, base);
+  }
+}
+
+function mergeSessionCookies(source: NextResponse, target: NextResponse) {
+  source.headers.forEach((value, key) => {
+    if (key.toLowerCase() === "set-cookie") {
+      target.headers.append(key, value);
+    }
+  });
+  return target;
+}
+
+function validateEmail(value: string) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+function normalizeUsername(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  return trimmed.toLowerCase();
+}
+
+function sanitizeAvatarUrl(value: string) {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    if (!["http:", "https:"].includes(parsed.protocol)) {
+      throw new Error("URL harus menggunakan protokol http atau https");
+    }
+    return trimmed;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "URL foto profil tidak valid";
+    throw new Error(message);
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const res = new NextResponse();
+  const session = await getIronSession<{ user?: SessionUser }>(req, res, sessionOptions);
+  const actor = session.user;
+
+  const form = await req.formData();
+  const redirectUrl = resolveRedirect(form.get("redirectTo"), req.url, "/account");
+
+  if (!actor) {
+    return NextResponse.redirect(new URL("/seller/login", req.url));
+  }
+
+  const nameRaw = form.get("name");
+  const emailRaw = form.get("email");
+  const usernameRaw = form.get("username");
+  const phoneRaw = form.get("phoneNumber");
+  const genderRaw = form.get("gender");
+  const avatarRaw = form.get("avatarUrl");
+
+  const name = typeof nameRaw === "string" ? nameRaw.trim() : "";
+  const email = typeof emailRaw === "string" ? emailRaw.trim().toLowerCase() : "";
+  const usernameNormalized = typeof usernameRaw === "string" ? normalizeUsername(usernameRaw) : "";
+  const phoneNumber = typeof phoneRaw === "string" ? phoneRaw.trim() : "";
+  const gender = typeof genderRaw === "string" && genderRaw ? genderRaw : "";
+
+  let avatarUrl: string | null = null;
+
+  try {
+    if (typeof avatarRaw === "string") {
+      avatarUrl = sanitizeAvatarUrl(avatarRaw);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "URL foto profil tidak valid";
+    redirectUrl.searchParams.set("profileError", message);
+    redirectUrl.searchParams.delete("profileUpdated");
+    const response = NextResponse.redirect(redirectUrl);
+    return mergeSessionCookies(res, response);
+  }
+
+  if (!name) {
+    redirectUrl.searchParams.set("profileError", "Nama wajib diisi.");
+    redirectUrl.searchParams.delete("profileUpdated");
+    const response = NextResponse.redirect(redirectUrl);
+    return mergeSessionCookies(res, response);
+  }
+
+  if (!email || !validateEmail(email)) {
+    redirectUrl.searchParams.set("profileError", "Email tidak valid.");
+    redirectUrl.searchParams.delete("profileUpdated");
+    const response = NextResponse.redirect(redirectUrl);
+    return mergeSessionCookies(res, response);
+  }
+
+  if (usernameNormalized && usernameNormalized.length < 3) {
+    redirectUrl.searchParams.set("profileError", "Username minimal 3 karakter.");
+    redirectUrl.searchParams.delete("profileUpdated");
+    const response = NextResponse.redirect(redirectUrl);
+    return mergeSessionCookies(res, response);
+  }
+
+  if (phoneNumber && phoneNumber.length < 6) {
+    redirectUrl.searchParams.set("profileError", "Nomor telepon minimal 6 digit.");
+    redirectUrl.searchParams.delete("profileUpdated");
+    const response = NextResponse.redirect(redirectUrl);
+    return mergeSessionCookies(res, response);
+  }
+
+  const allowedGenders = ["MALE", "FEMALE", "OTHER"] as const;
+  let genderValue: typeof allowedGenders[number] | null = null;
+  if (gender) {
+    if (!allowedGenders.includes(gender as (typeof allowedGenders)[number])) {
+      redirectUrl.searchParams.set("profileError", "Jenis kelamin tidak valid.");
+      redirectUrl.searchParams.delete("profileUpdated");
+      const response = NextResponse.redirect(redirectUrl);
+      return mergeSessionCookies(res, response);
+    }
+    genderValue = gender as (typeof allowedGenders)[number];
+  }
+
+  try {
+    await prisma.user.update({
+      where: { id: actor.id },
+      data: {
+        name,
+        email,
+        username: usernameNormalized ? usernameNormalized : null,
+        phoneNumber: phoneNumber || null,
+        gender: genderValue ?? null,
+        avatarUrl,
+      },
+    });
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+      redirectUrl.searchParams.set("profileError", "Username sudah digunakan.");
+    } else {
+      const message = error instanceof Error ? error.message : "Gagal memperbarui profil.";
+      redirectUrl.searchParams.set("profileError", message);
+    }
+    redirectUrl.searchParams.delete("profileUpdated");
+    const response = NextResponse.redirect(redirectUrl);
+    return mergeSessionCookies(res, response);
+  }
+
+  session.user = { ...actor, name, email };
+  await session.save();
+
+  redirectUrl.searchParams.delete("profileError");
+  redirectUrl.searchParams.set("profileUpdated", "1");
+
+  const response = NextResponse.redirect(redirectUrl);
+  return mergeSessionCookies(res, response);
+}

--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -3,22 +3,23 @@ import { prisma } from "@/lib/prisma";
 import { COURIERS } from "@/lib/shipping";
 import { getSession } from "@/lib/session";
 import { calculateFlashSalePrice } from "@/lib/flash-sale";
+import { sendOrderCreatedEmail } from "@/lib/email";
 
 export const runtime = "nodejs";
 
 export async function POST(req: NextRequest) {
   const form = await req.formData();
-  const buyerName = String(form.get('buyerName') || '');
-  const buyerPhone = String(form.get('buyerPhone') || '');
-  const buyerEmail = String(form.get('buyerEmail') || '').toLowerCase();
-  const buyerAddress = String(form.get('buyerAddress') || '');
+  let buyerName = String(form.get('buyerName') || '');
+  let buyerPhone = String(form.get('buyerPhone') || '');
+  let buyerEmail = String(form.get('buyerEmail') || '').toLowerCase();
+  let buyerAddress = String(form.get('buyerAddress') || '');
   const courierKey = String(form.get('courier') || 'JNE_REG') as keyof typeof COURIERS;
   const items = JSON.parse(String(form.get('items') || '[]')) as { productId: string; qty: number }[];
   const paymentMethod = String(form.get('paymentMethod') || 'TRANSFER') as 'TRANSFER'|'COD';
   const voucherCode = String(form.get('voucher') || '').trim().toUpperCase();
 
-  if (!buyerName || !buyerPhone || !buyerAddress || !buyerEmail || !items.length) {
-    return NextResponse.json({ error: 'Invalid' }, { status: 400 });
+  if (!items.length) {
+    return NextResponse.json({ error: 'Keranjang kosong' }, { status: 400 });
   }
   const courier = COURIERS[courierKey];
   const products = await prisma.product.findMany({ where: { id: { in: items.map(i => i.productId) } } });
@@ -27,10 +28,71 @@ export async function POST(req: NextRequest) {
   const session = await getSession();
   const buyerId = session.user?.id ?? null;
   if (buyerId) {
+    const account = await prisma.user.findUnique({
+      where: { id: buyerId },
+      select: {
+        name: true,
+        email: true,
+        phoneNumber: true,
+        addresses: {
+          orderBy: [
+            { isDefault: 'desc' },
+            { createdAt: 'desc' },
+          ],
+          select: {
+            fullName: true,
+            phoneNumber: true,
+            province: true,
+            city: true,
+            district: true,
+            postalCode: true,
+            addressLine: true,
+            additionalInfo: true,
+            isDefault: true,
+          },
+        },
+      },
+    });
+
+    if (!account || account.addresses.length === 0) {
+      return NextResponse.json(
+        { error: 'Silakan tambahkan alamat pengiriman di Akun Saya sebelum melanjutkan checkout.' },
+        { status: 400 },
+      );
+    }
+
+    const defaultAddress =
+      account.addresses.find((address) => address.isDefault) ?? account.addresses[0];
+
+    if (!buyerName) {
+      buyerName = defaultAddress.fullName || account.name;
+    }
+    if (!buyerPhone) {
+      buyerPhone = defaultAddress.phoneNumber || account.phoneNumber || '';
+    }
+    if (!buyerEmail) {
+      buyerEmail = account.email;
+    }
+    if (!buyerAddress) {
+      const addressParts = [
+        defaultAddress.addressLine,
+        defaultAddress.district,
+        defaultAddress.city,
+        defaultAddress.province,
+        defaultAddress.postalCode ? `Kode Pos ${defaultAddress.postalCode}` : '',
+        defaultAddress.additionalInfo || '',
+      ];
+      buyerAddress = addressParts.filter(Boolean).join(', ');
+    }
+
     const ownsProduct = products.some((product) => product.sellerId === buyerId);
     if (ownsProduct) {
       return NextResponse.json({ error: 'Penjual tidak dapat membeli produknya sendiri' }, { status: 400 });
     }
+  }
+
+  if (!buyerName || !buyerPhone || !buyerAddress || !buyerEmail) {
+    return NextResponse.json({ error: 'Data pembeli tidak lengkap' }, { status: 400 });
   }
 
   const now = new Date();
@@ -87,7 +149,7 @@ export async function POST(req: NextRequest) {
   const order = await prisma.order.create({
     data: {
       orderCode,
-      buyerName, buyerPhone, buyerAddress,
+      buyerName, buyerPhone, buyerAddress, buyerEmail,
       buyerId,
       courier: courier.label,
       shippingCost,

--- a/app/api/seller/item-status/route.ts
+++ b/app/api/seller/item-status/route.ts
@@ -29,7 +29,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.redirect(new URL('/seller/onboarding', req.url));
   }
 
-  const item = await prisma.orderItem.findUnique({ where: { id: orderItemId }, include: { order: true } });
+  const item = await prisma.orderItem.findUnique({ where: { id: orderItemId }, include: { order: { include: { items: true } } } });
   if (!item || item.sellerId !== user.id || item.order.orderCode !== orderCode) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
   if (item.status === status) {

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -1,61 +1,269 @@
-'use client';
+"use client";
 import { COURIERS } from "@/lib/shipping";
 import { useEffect, useState } from "react";
+
 type CartItem = { productId: string; title: string; price: number; qty: number; sellerId: string };
+
+type CheckoutAccountData = {
+  profile: {
+    name: string;
+    email: string;
+    phoneNumber: string | null;
+  };
+  defaultAddress: {
+    fullName: string;
+    phoneNumber: string;
+    province: string;
+    city: string;
+    district: string;
+    postalCode: string;
+    addressLine: string;
+    additionalInfo: string | null;
+  } | null;
+  addressesCount: number;
+};
+
+type CheckoutResponse = {
+  orderCode?: string;
+  error?: string;
+};
+
+function formatAddress(address: NonNullable<CheckoutAccountData["defaultAddress"]>) {
+  return [
+    address.addressLine,
+    address.district,
+    address.city,
+    address.province,
+    address.postalCode ? `Kode Pos ${address.postalCode}` : "",
+    address.additionalInfo ?? "",
+  ]
+    .filter(Boolean)
+    .join(", ");
+}
 
 export default function CheckoutPage() {
   const [items, setItems] = useState<CartItem[]>([]);
   const [total, setTotal] = useState(0);
   const [courier, setCourier] = useState<keyof typeof COURIERS>('JNE_REG');
+  const [accountData, setAccountData] = useState<CheckoutAccountData | null>(null);
+  const [accountLoading, setAccountLoading] = useState(true);
+  const [accountError, setAccountError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
     const raw = localStorage.getItem('cart');
     const arr: CartItem[] = raw ? JSON.parse(raw) : [];
-    setItems(arr); setTotal(arr.reduce((s, it) => s + it.price * it.qty, 0));
+    setItems(arr);
+    setTotal(arr.reduce((s, it) => s + it.price * it.qty, 0));
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadAccount() {
+      try {
+        const res = await fetch('/api/account/checkout-data', { credentials: 'include' });
+        if (res.status === 401) {
+          return;
+        }
+
+        const payload = await res.json().catch(() => null);
+        if (!res.ok) {
+          const message = typeof payload?.error === 'string' ? payload.error : 'Gagal memuat data akun.';
+          throw new Error(message);
+        }
+
+        if (!cancelled && payload) {
+          setAccountData(payload as CheckoutAccountData);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          const message = error instanceof Error ? error.message : 'Gagal memuat data akun.';
+          setAccountError(message);
+        }
+      } finally {
+        if (!cancelled) {
+          setAccountLoading(false);
+        }
+      }
+    }
+
+    loadAccount();
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   async function submit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
+    if (!items.length) {
+      alert('Keranjang Anda kosong.');
+      return;
+    }
+
     const fd = new FormData(e.currentTarget);
     fd.append('items', JSON.stringify(items));
     fd.append('courier', courier);
-    const res = await fetch('/api/checkout', { method: 'POST', body: fd });
-    if (!res.ok) { alert('Gagal membuat pesanan'); return; }
-    const data = await res.json();
-    const orderCode = typeof data?.orderCode === 'string' ? data.orderCode : '';
-    localStorage.removeItem('cart');
-    window.location.href = `/order/${orderCode || data.orderCode}`;
+
+    setSubmitting(true);
+    try {
+      const res = await fetch('/api/checkout', { method: 'POST', body: fd });
+      const payload = (await res.json().catch(() => null)) as CheckoutResponse | null;
+      if (!res.ok || !payload || typeof payload.orderCode !== 'string') {
+        const message = payload?.error ?? 'Gagal membuat pesanan';
+        alert(message);
+        return;
+      }
+
+      localStorage.removeItem('cart');
+      window.location.href = `/order/${payload.orderCode}`;
+    } finally {
+      setSubmitting(false);
+    }
   }
+
+  const hasPrefilledAddress = Boolean(accountData?.defaultAddress);
+  const loggedInWithoutAddress = Boolean(accountData && accountData.addressesCount === 0 && !accountData.defaultAddress);
+  const defaultAddress = accountData?.defaultAddress ?? null;
+  const defaultName = hasPrefilledAddress
+    ? (defaultAddress?.fullName?.trim() || accountData?.profile.name || '')
+    : '';
+  const defaultPhone = hasPrefilledAddress
+    ? (defaultAddress?.phoneNumber?.trim() || accountData?.profile.phoneNumber || '')
+    : '';
+  const defaultEmail = hasPrefilledAddress ? accountData?.profile.email ?? '' : '';
+  const defaultAddressText = hasPrefilledAddress && defaultAddress ? formatAddress(defaultAddress) : '';
+  const missingPrefilledFields = hasPrefilledAddress && (!defaultName || !defaultPhone || !defaultEmail || !defaultAddressText);
+
+  const disableSubmit =
+    submitting ||
+    items.length === 0 ||
+    loggedInWithoutAddress ||
+    (missingPrefilledFields ?? false);
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
       <div className="bg-white border rounded p-4">
         <h2 className="font-semibold mb-2">Data Pembeli</h2>
         <form onSubmit={submit} className="space-y-3">
-          <input name="buyerName" required placeholder="Nama Lengkap" className="border rounded w-full px-3 py-2"/>
-          <input name="buyerPhone" required placeholder="No. WhatsApp (08xxxx)" className="border rounded w-full px-3 py-2"/>
-          <input name="buyerEmail" type="email" required placeholder="Email" className="border rounded w-full px-3 py-2"/>
-          <textarea name="buyerAddress" required placeholder="Alamat Lengkap" className="border rounded w-full px-3 py-2"/>
+          {accountLoading ? (
+            <div className="rounded border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-600">
+              Memuat data akun...
+            </div>
+          ) : null}
+
+          {accountError ? (
+            <div className="rounded border border-yellow-200 bg-yellow-50 px-4 py-3 text-sm text-yellow-800">
+              {accountError}
+            </div>
+          ) : null}
+
+          {loggedInWithoutAddress ? (
+            <div className="rounded border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+              Anda belum menyimpan alamat pengiriman. Silakan tambahkan alamat di{' '}
+              <a href="/account" className="font-semibold text-amber-900 underline">
+                Akun Saya
+              </a>{' '}
+              sebelum melanjutkan checkout.
+            </div>
+          ) : null}
+
+          {hasPrefilledAddress ? (
+            <div className="space-y-3">
+              <input type="hidden" name="buyerName" value={defaultName} />
+              <input type="hidden" name="buyerPhone" value={defaultPhone} />
+              <input type="hidden" name="buyerEmail" value={defaultEmail} />
+              <input type="hidden" name="buyerAddress" value={defaultAddressText} />
+
+              <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-800">
+                <p className="font-semibold text-emerald-900">Alamat tersimpan digunakan otomatis</p>
+                <p className="mt-1 text-emerald-900">{defaultName}</p>
+                <p className="text-emerald-900">{defaultPhone}</p>
+                <p className="text-emerald-900">{defaultEmail}</p>
+                <p className="mt-2 whitespace-pre-line text-emerald-900">{defaultAddressText}</p>
+                <p className="mt-3 text-emerald-900">
+                  Perbarui data profil atau alamat melalui{' '}
+                  <a href="/account" className="font-semibold underline">
+                    Akun Saya
+                  </a>
+                  .
+                </p>
+                {missingPrefilledFields ? (
+                  <p className="mt-3 font-semibold text-emerald-900">
+                    Lengkapi nama, email, nomor telepon, dan alamat di Akun Saya agar dapat melanjutkan checkout.
+                  </p>
+                ) : null}
+              </div>
+            </div>
+          ) : null}
+
+          {!accountLoading && !hasPrefilledAddress && !loggedInWithoutAddress ? (
+            <>
+              <input
+                name="buyerName"
+                required
+                placeholder="Nama Lengkap"
+                defaultValue={accountData?.profile.name ?? ''}
+                className="border rounded w-full px-3 py-2"
+              />
+              <input
+                name="buyerPhone"
+                required
+                placeholder="No. WhatsApp (08xxxx)"
+                defaultValue={accountData?.profile.phoneNumber ?? ''}
+                className="border rounded w-full px-3 py-2"
+              />
+              <input
+                name="buyerEmail"
+                type="email"
+                required
+                placeholder="Email"
+                defaultValue={accountData?.profile.email ?? ''}
+                className="border rounded w-full px-3 py-2"
+              />
+              <textarea
+                name="buyerAddress"
+                required
+                placeholder="Alamat Lengkap"
+                className="border rounded w-full px-3 py-2"
+              />
+            </>
+          ) : null}
+
           <div>
             <label className="block text-sm mb-1">Kurir</label>
-            <select value={courier} onChange={(e)=>setCourier(e.target.value as any)} className="border rounded w-full px-3 py-2">
-              {Object.entries(COURIERS).map(([k,v]) => <option key={k} value={k}>{v.label} (Rp {new Intl.NumberFormat('id-ID').format(v.cost)})</option>)}
+            <select value={courier} onChange={(e)=>setCourier(e.target.value as keyof typeof COURIERS)} className="border rounded w-full px-3 py-2">
+              {Object.entries(COURIERS).map(([k,v]) => (
+                <option key={k} value={k}>
+                  {v.label} (Rp {new Intl.NumberFormat('id-ID').format(v.cost)})
+                </option>
+              ))}
             </select>
             <p className="text-xs text-gray-500 mt-1">Ongkir dihitung per gudang (per-shipment) di server.</p>
           </div>
+
           <div>
             <label className="block text-sm mb-1">Metode Pembayaran</label>
             <div className="flex gap-4 text-sm">
-              <label className="flex items-center gap-2"><input type="radio" name="paymentMethod" value="TRANSFER" defaultChecked/> Transfer Manual</label>
-              <label className="flex items-center gap-2"><input type="radio" name="paymentMethod" value="COD"/> COD (Bayar di Tempat)</label>
+              <label className="flex items-center gap-2">
+                <input type="radio" name="paymentMethod" value="TRANSFER" defaultChecked /> Transfer Manual
+              </label>
+              <label className="flex items-center gap-2">
+                <input type="radio" name="paymentMethod" value="COD" /> COD (Bayar di Tempat)
+              </label>
             </div>
           </div>
+
           <div>
             <label className="block text-sm mb-1">Voucher</label>
             <input name="voucher" placeholder="KODEVOUCHER" className="border rounded w-full px-3 py-2"/>
             <p className="text-xs text-gray-500 mt-1">* Potongan diterapkan ke total barang (belum termasuk ongkir & kode unik).</p>
           </div>
-          <button className="btn-primary">Buat Pesanan</button>
+
+          <button className="btn-primary disabled:opacity-60" disabled={disableSubmit}>
+            {submitting ? 'Memproses...' : 'Buat Pesanan'}
+          </button>
         </form>
       </div>
       <div className="bg-white border rounded p-4">

--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -77,7 +77,7 @@ export function SiteHeader({ user }: SiteHeaderProps) {
                 {open && (
                   <div className="absolute right-0 z-50 mt-2 w-48 overflow-hidden rounded-md bg-white text-gray-700 shadow-lg">
                     <Link
-                      href="/seller/dashboard"
+                      href="/account"
                       className="block px-4 py-3 text-sm font-medium hover:bg-gray-100"
                       onClick={() => setOpen(false)}
                     >

--- a/prisma/migrations/20251004000015_add_buyer_account_profile/migration.sql
+++ b/prisma/migrations/20251004000015_add_buyer_account_profile/migration.sql
@@ -1,0 +1,37 @@
+-- CreateEnum
+CREATE TYPE "Gender" AS ENUM ('MALE', 'FEMALE', 'OTHER');
+
+-- AlterTable
+ALTER TABLE "User"
+  ADD COLUMN "username" TEXT,
+  ADD COLUMN "phoneNumber" TEXT,
+  ADD COLUMN "gender" "Gender";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_username_key" ON "User"("username");
+
+-- CreateTable
+CREATE TABLE "UserAddress" (
+  "id" TEXT PRIMARY KEY,
+  "userId" TEXT NOT NULL,
+  "fullName" TEXT NOT NULL,
+  "phoneNumber" TEXT NOT NULL,
+  "province" TEXT NOT NULL,
+  "city" TEXT NOT NULL,
+  "district" TEXT NOT NULL,
+  "postalCode" TEXT NOT NULL,
+  "addressLine" TEXT NOT NULL,
+  "additionalInfo" TEXT,
+  "isDefault" BOOLEAN NOT NULL DEFAULT FALSE,
+  "createdAt" TIMESTAMP NOT NULL DEFAULT NOW(),
+  "updatedAt" TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- AddForeignKey
+ALTER TABLE "UserAddress"
+  ADD CONSTRAINT "UserAddress_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "User"("id")
+  ON UPDATE CASCADE ON DELETE CASCADE;
+
+-- CreateIndex
+CREATE INDEX "UserAddress_userId_idx" ON "UserAddress"("userId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,6 +18,9 @@ model User {
   sellerOnboardingStatus SellerOnboardingStatus @default(ACTIVE)
   createdAt    DateTime @default(now())
   avatarUrl    String?
+  username     String?  @unique
+  phoneNumber  String?
+  gender       Gender?
   storeBadge   StoreBadge @default(BASIC)
   storeIsOnline Boolean   @default(true)
   storeFollowers Int      @default(0)
@@ -33,6 +36,7 @@ model User {
   warehouses   Warehouse[]
   flashSales   FlashSale[]
   passwordResetTokens PasswordResetToken[]
+  addresses    UserAddress[]
 }
 
 enum SellerOnboardingStatus {
@@ -72,6 +76,12 @@ model Product {
   orderItems   OrderItem[]
   images       ProductImage[]
   flashSales   FlashSale[]
+}
+
+enum Gender {
+  MALE
+  FEMALE
+  OTHER
 }
 
 model FlashSale {
@@ -120,6 +130,7 @@ model Order {
   buyerName        String
   buyerPhone       String
   buyerAddress     String
+  buyerEmail       String?
   buyerId          String?
   buyer            User?         @relation("BuyerOrders", fields: [buyerId], references: [id])
   courier          String
@@ -144,6 +155,25 @@ model Order {
   logs             VerificationLog[]
   returns          ReturnRequest[]
   review           OrderReview?
+}
+
+model UserAddress {
+  id            String   @id @default(cuid())
+  userId        String
+  user          User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  fullName      String
+  phoneNumber   String
+  province      String
+  city          String
+  district      String
+  postalCode    String
+  addressLine   String
+  additionalInfo String?
+  isDefault     Boolean  @default(false)
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  @@index([userId])
 }
 
 model OrderReview {


### PR DESCRIPTION
## Summary
- add an account checkout-data endpoint so logged-in buyers can retrieve their saved profile and address details
- require buyers to save an address before checkout and automatically fill missing buyer fields on the server from the stored default address
- update the checkout page to fetch saved data, prefill the form, and block checkout until an address is added in Akun Saya

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4f12844888320bea172b5108fc06c