### PR TITLE
Implement province dropdown with remote data fallback

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 
+import { ProvinceSelect } from "@/components/ProvinceSelect";
 import { prisma } from "@/lib/prisma";
 import { getSession } from "@/lib/session";
 import type { Gender } from "@prisma/client";
@@ -299,10 +300,9 @@ export default async function AccountPage({ searchParams }: AccountPageProps) {
             <label htmlFor="province" className="text-sm font-medium text-gray-700">
               Provinsi
             </label>
-            <input
+            <ProvinceSelect
               id="province"
               name="province"
-              type="text"
               required
               className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
             />

--- a/components/ProvinceSelect.tsx
+++ b/components/ProvinceSelect.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+type Province = {
+  id: string;
+  name: string;
+};
+
+type ProvinceSelectProps = {
+  id?: string;
+  name?: string;
+  required?: boolean;
+  defaultValue?: string;
+  className?: string;
+};
+
+const PROVINCES_ENDPOINT =
+  "https://www.emsifa.com/api-wilayah-indonesia/api/provinces.json";
+
+export function ProvinceSelect({
+  id,
+  name,
+  required,
+  defaultValue,
+  className,
+}: ProvinceSelectProps) {
+  const [provinces, setProvinces] = useState<Province[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    async function fetchProvinces() {
+      setIsLoading(true);
+      try {
+        const response = await fetch(PROVINCES_ENDPOINT, {
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          throw new Error(`Request failed with status ${response.status}`);
+        }
+
+        const data: Province[] = await response.json();
+
+        if (!Array.isArray(data)) {
+          throw new Error("Invalid response shape");
+        }
+
+        setProvinces(
+          data
+            .filter((province): province is Province =>
+              Boolean(province && province.id && province.name),
+            )
+            .map((province) => ({
+              id: String(province.id),
+              name: province.name.trim(),
+            }))
+            .sort((a, b) => a.name.localeCompare(b.name)),
+        );
+        setError(null);
+      } catch (err) {
+        if ((err as Error).name === "AbortError") {
+          return;
+        }
+        console.error("Failed to load provinces", err);
+        setError("Gagal memuat daftar provinsi. Silakan isi secara manual.");
+        setProvinces(null);
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    void fetchProvinces();
+
+    return () => {
+      controller.abort();
+    };
+  }, []);
+
+  const normalizedDefaultValue = useMemo(() => defaultValue?.trim() ?? "", [defaultValue]);
+
+  if (error) {
+    return (
+      <div className="space-y-1">
+        <input
+          id={id}
+          name={name}
+          type="text"
+          required={required}
+          defaultValue={normalizedDefaultValue}
+          placeholder="Tulis provinsi"
+          className={className}
+        />
+        <p className="text-xs text-red-600">{error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <select
+      id={id}
+      name={name}
+      required={required}
+      defaultValue={normalizedDefaultValue}
+      className={className}
+      disabled={isLoading && !provinces}
+    >
+      <option value="">{isLoading ? "Memuat provinsi..." : "Pilih provinsi"}</option>
+      {(provinces ?? []).map((province) => (
+        <option key={province.id} value={province.name}>
+          {province.name}
+        </option>
+      ))}
+    </select>
+  );
+}


### PR DESCRIPTION
## Summary
- add a client-side ProvinceSelect component that loads Indonesian provinces and gracefully degrades to manual input if the request fails
- use the new ProvinceSelect on the account address form so buyers can pick a province from a dropdown

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e50396659c832086e2c3afaa67e04b