### PR TITLE
Integrate RajaOngkir shipping cost into checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Marketplace ala Shopee dengan **transfer manual + kode unik**, **COD**, **vouche
 ## Fitur
 - **Pembayaran**: TRANSFER (kode unik 111–999) & COD (tanpa kode unik)
 - **Voucher**: percent/fixed, min spend, expiry, active
-- **Multi-gudang**: produk dapat di-assign ke gudang seller; ongkir dihitung **per gudang** (per-shipment)
+- **Multi-gudang**: produk dapat di-assign ke gudang seller; ongkir dihitung **per gudang** (per-shipment) dengan tarif RajaOngkir real-time
 - **Retur** per item: buyer ajukan, seller approve/reject (extendable: RECEIVED/REFUND)
 - **WhatsApp** auto-template untuk konfirmasi transfer
 - **Admin**: mark order paid
@@ -32,6 +32,8 @@ Marketplace ala Shopee dengan **transfer manual + kode unik**, **COD**, **vouche
 - `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM` (untuk mengirim OTP reset password). Saat variabel ini tidak diisi, email akan dicetak ke log saja.
 - `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI` (opsional — default ke `/api/auth/google/callback` sesuai origin) untuk login Google.
 - `REDIS_URL` untuk presence, typing indicator, dan antrian notifikasi chat.
+- `RAJAONGKIR_API_KEY` (wajib) dan `RAJAONGKIR_API_BASE_URL` (opsional, default `https://api.rajaongkir.com/starter/`) untuk sinkronisasi daftar provinsi/kota/kecamatan.
+- `RAJAONGKIR_DEFAULT_ORIGIN_CITY_ID` (disarankan) atau `RAJAONGKIR_DEFAULT_ORIGIN_CITY` sebagai fallback kota asal ketika gudang tidak memiliki kota tersimpan. Nilai ini dipakai saat menghitung ongkir melalui RajaOngkir.
 - `PLATFORM_NAME`, `BANK_*`, `ACCOUNT_NAME`, `BASE_URL`, `ADMIN_EMAIL`, `ADMIN_PASSWORD`
 
 ## Deploy Vercel

--- a/app/api/account/addresses/[addressId]/route.ts
+++ b/app/api/account/addresses/[addressId]/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { getSession } from "@/lib/session";
+
+import { parseAddressForm, resolveRedirect } from "../utils";
+
+export const runtime = "nodejs";
+
+type RouteParams = {
+  params: {
+    addressId: string;
+  };
+};
+
+export async function POST(req: NextRequest, { params }: RouteParams) {
+  const session = await getSession();
+  const actor = session.user;
+  const addressId = params.addressId;
+
+  const form = await req.formData();
+  const redirectUrl = resolveRedirect(form.get("redirectTo"), req.url, "/account");
+
+  if (!actor) {
+    return NextResponse.redirect(new URL("/seller/login", req.url));
+  }
+
+  if (!addressId) {
+    redirectUrl.searchParams.set("addressError", "Alamat tidak ditemukan.");
+    redirectUrl.searchParams.delete("addressAdded");
+    redirectUrl.searchParams.delete("addressUpdated");
+    redirectUrl.searchParams.delete("editAddress");
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  const parsed = parseAddressForm(form);
+
+  if (!parsed.success) {
+    redirectUrl.searchParams.set("addressError", parsed.error);
+    redirectUrl.searchParams.delete("addressAdded");
+    redirectUrl.searchParams.delete("addressUpdated");
+    redirectUrl.searchParams.set("editAddress", addressId);
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  try {
+    const target = await prisma.userAddress.findUnique({
+      where: { id: addressId },
+      select: { id: true, userId: true },
+    });
+
+    if (!target || target.userId !== actor.id) {
+      redirectUrl.searchParams.set("addressError", "Alamat tidak ditemukan.");
+      redirectUrl.searchParams.delete("addressAdded");
+      redirectUrl.searchParams.delete("addressUpdated");
+      redirectUrl.searchParams.delete("editAddress");
+      return NextResponse.redirect(redirectUrl);
+    }
+
+    await prisma.userAddress.update({
+      where: { id: addressId },
+      data: parsed.data,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Gagal memperbarui alamat.";
+    redirectUrl.searchParams.set("addressError", message);
+    redirectUrl.searchParams.delete("addressAdded");
+    redirectUrl.searchParams.delete("addressUpdated");
+    redirectUrl.searchParams.set("editAddress", addressId);
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  redirectUrl.searchParams.delete("addressError");
+  redirectUrl.searchParams.delete("addressAdded");
+  redirectUrl.searchParams.set("addressUpdated", "1");
+  redirectUrl.searchParams.delete("editAddress");
+
+  return NextResponse.redirect(redirectUrl);
+}

--- a/app/api/account/addresses/route.ts
+++ b/app/api/account/addresses/route.ts
@@ -3,24 +3,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getSession } from "@/lib/session";
 
+import { parseAddressForm, resolveRedirect } from "./utils";
+
 export const runtime = "nodejs";
-
-function resolveRedirect(redirectTo: FormDataEntryValue | null, reqUrl: string, fallback: string) {
-  const base = new URL(reqUrl);
-  if (typeof redirectTo !== "string" || redirectTo.trim().length === 0) {
-    return new URL(fallback, base);
-  }
-
-  try {
-    const target = new URL(redirectTo, base);
-    if (target.origin !== base.origin) {
-      return new URL(fallback, base);
-    }
-    return target;
-  } catch {
-    return new URL(fallback, base);
-  }
-}
 
 export async function POST(req: NextRequest) {
   const session = await getSession();
@@ -33,54 +18,12 @@ export async function POST(req: NextRequest) {
     return NextResponse.redirect(new URL("/seller/login", req.url));
   }
 
-  const fullNameRaw = form.get("fullName");
-  const phoneRaw = form.get("phoneNumber");
-  const provinceRaw = form.get("province");
-  const cityRaw = form.get("city");
-  const districtRaw = form.get("district");
-  const postalCodeRaw = form.get("postalCode");
-  const addressLineRaw = form.get("addressLine");
-  const additionalRaw = form.get("additionalInfo");
+  const parsed = parseAddressForm(form);
 
-  const fullName = typeof fullNameRaw === "string" ? fullNameRaw.trim() : "";
-  const phoneNumber = typeof phoneRaw === "string" ? phoneRaw.trim() : "";
-  const province = typeof provinceRaw === "string" ? provinceRaw.trim() : "";
-  const city = typeof cityRaw === "string" ? cityRaw.trim() : "";
-  const district = typeof districtRaw === "string" ? districtRaw.trim() : "";
-  const postalCode = typeof postalCodeRaw === "string" ? postalCodeRaw.trim() : "";
-  const addressLine = typeof addressLineRaw === "string" ? addressLineRaw.trim() : "";
-  const additionalInfo = typeof additionalRaw === "string" ? additionalRaw.trim() : "";
-
-  const requiredFields: [string, string][] = [
-    ["Nama Lengkap", fullName],
-    ["Nomor telepon", phoneNumber],
-    ["Provinsi", province],
-    ["Kota", city],
-    ["Kecamatan", district],
-    ["Kode pos", postalCode],
-    ["Alamat lengkap", addressLine],
-  ];
-
-  for (const [label, value] of requiredFields) {
-    if (!value) {
-      redirectUrl.searchParams.set(
-        "addressError",
-        `${label} wajib diisi.`,
-      );
-      redirectUrl.searchParams.delete("addressAdded");
-      return NextResponse.redirect(redirectUrl);
-    }
-  }
-
-  if (!/^\d{4,10}$/.test(postalCode)) {
-    redirectUrl.searchParams.set("addressError", "Kode pos harus berupa 4-10 digit angka.");
+  if (!parsed.success) {
+    redirectUrl.searchParams.set("addressError", parsed.error);
     redirectUrl.searchParams.delete("addressAdded");
-    return NextResponse.redirect(redirectUrl);
-  }
-
-  if (phoneNumber && !/^\+?\d{6,15}$/.test(phoneNumber)) {
-    redirectUrl.searchParams.set("addressError", "Nomor telepon tidak valid.");
-    redirectUrl.searchParams.delete("addressAdded");
+    redirectUrl.searchParams.delete("addressUpdated");
     return NextResponse.redirect(redirectUrl);
   }
 
@@ -88,25 +31,21 @@ export async function POST(req: NextRequest) {
     await prisma.userAddress.create({
       data: {
         userId: actor.id,
-        fullName,
-        phoneNumber,
-        province,
-        city,
-        district,
-        postalCode,
-        addressLine,
-        additionalInfo: additionalInfo || null,
+        ...parsed.data,
       },
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Gagal menambahkan alamat.";
     redirectUrl.searchParams.set("addressError", message);
     redirectUrl.searchParams.delete("addressAdded");
+    redirectUrl.searchParams.delete("addressUpdated");
     return NextResponse.redirect(redirectUrl);
   }
 
   redirectUrl.searchParams.delete("addressError");
   redirectUrl.searchParams.set("addressAdded", "1");
+  redirectUrl.searchParams.delete("addressUpdated");
+  redirectUrl.searchParams.delete("editAddress");
 
   return NextResponse.redirect(redirectUrl);
 }

--- a/app/api/account/addresses/utils.ts
+++ b/app/api/account/addresses/utils.ts
@@ -1,0 +1,93 @@
+type AddressFormResult =
+  | { success: true; data: AddressFormData }
+  | { success: false; error: string };
+
+export type AddressFormData = {
+  fullName: string;
+  phoneNumber: string;
+  province: string;
+  city: string;
+  district: string;
+  postalCode: string;
+  addressLine: string;
+  additionalInfo: string | null;
+};
+
+export function resolveRedirect(
+  redirectTo: FormDataEntryValue | null,
+  reqUrl: string,
+  fallback: string,
+) {
+  const base = new URL(reqUrl);
+  if (typeof redirectTo !== "string" || redirectTo.trim().length === 0) {
+    return new URL(fallback, base);
+  }
+
+  try {
+    const target = new URL(redirectTo, base);
+    if (target.origin !== base.origin) {
+      return new URL(fallback, base);
+    }
+    return target;
+  } catch {
+    return new URL(fallback, base);
+  }
+}
+
+export function parseAddressForm(form: FormData): AddressFormResult {
+  const fullNameRaw = form.get("fullName");
+  const phoneRaw = form.get("phoneNumber");
+  const provinceRaw = form.get("province");
+  const cityRaw = form.get("city");
+  const districtRaw = form.get("district");
+  const postalCodeRaw = form.get("postalCode");
+  const addressLineRaw = form.get("addressLine");
+  const additionalRaw = form.get("additionalInfo");
+
+  const fullName = typeof fullNameRaw === "string" ? fullNameRaw.trim() : "";
+  const phoneNumber = typeof phoneRaw === "string" ? phoneRaw.trim() : "";
+  const province = typeof provinceRaw === "string" ? provinceRaw.trim() : "";
+  const city = typeof cityRaw === "string" ? cityRaw.trim() : "";
+  const district = typeof districtRaw === "string" ? districtRaw.trim() : "";
+  const postalCode = typeof postalCodeRaw === "string" ? postalCodeRaw.trim() : "";
+  const addressLine = typeof addressLineRaw === "string" ? addressLineRaw.trim() : "";
+  const additionalInfo = typeof additionalRaw === "string" ? additionalRaw.trim() : "";
+
+  const requiredFields: [string, string][] = [
+    ["Nama Lengkap", fullName],
+    ["Nomor telepon", phoneNumber],
+    ["Provinsi", province],
+    ["Kota", city],
+    ["Kecamatan", district],
+    ["Kode pos", postalCode],
+    ["Alamat lengkap", addressLine],
+  ];
+
+  for (const [label, value] of requiredFields) {
+    if (!value) {
+      return { success: false, error: `${label} wajib diisi.` };
+    }
+  }
+
+  if (!/^\d{4,10}$/.test(postalCode)) {
+    return { success: false, error: "Kode pos harus berupa 4-10 digit angka." };
+  }
+
+  if (phoneNumber && !/^\+?\d{6,15}$/.test(phoneNumber)) {
+    return { success: false, error: "Nomor telepon tidak valid." };
+  }
+
+  return {
+    success: true,
+    data: {
+      fullName,
+      phoneNumber,
+      province,
+      city,
+      district,
+      postalCode,
+      addressLine,
+      additionalInfo: additionalInfo ? additionalInfo : null,
+    },
+  };
+}

--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { COURIERS } from "@/lib/shipping";
+import { COURIERS, DEFAULT_ITEM_WEIGHT_GRAMS } from "@/lib/shipping";
 import { getSession } from "@/lib/session";
 import { calculateFlashSalePrice } from "@/lib/flash-sale";
 import { sendOrderCreatedEmail } from "@/lib/email";
+import { fetchRajaOngkirCost, findCityIdByName } from "@/lib/rajaongkir";
 
 export const runtime = "nodejs";
 
@@ -22,11 +23,30 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Keranjang kosong' }, { status: 400 });
   }
   const courier = COURIERS[courierKey];
-  const products = await prisma.product.findMany({ where: { id: { in: items.map(i => i.productId) } } });
+  if (!courier) {
+    return NextResponse.json({ error: 'Kurir tidak didukung' }, { status: 400 });
+  }
+
+  const products = await prisma.product.findMany({
+    where: { id: { in: items.map(i => i.productId) } },
+    include: {
+      warehouse: {
+        select: {
+          id: true,
+          city: true,
+        },
+      },
+    },
+  });
   if (products.length !== items.length) return NextResponse.json({ error: 'Produk tidak valid' }, { status: 400 });
 
   const session = await getSession();
   const buyerId = session.user?.id ?? null;
+
+  const defaultOriginCityName = process.env.RAJAONGKIR_DEFAULT_ORIGIN_CITY?.trim() || null;
+  const defaultOriginCityId = process.env.RAJAONGKIR_DEFAULT_ORIGIN_CITY_ID?.trim() || null;
+  let shippingDestinationCity: string | null = null;
+  let shippingDestinationProvince: string | null = null;
   if (buyerId) {
     const account = await prisma.user.findUnique({
       where: { id: buyerId },
@@ -63,6 +83,9 @@ export async function POST(req: NextRequest) {
 
     const defaultAddress =
       account.addresses.find((address) => address.isDefault) ?? account.addresses[0];
+
+    shippingDestinationCity = defaultAddress.city;
+    shippingDestinationProvince = defaultAddress.province;
 
     if (!buyerName) {
       buyerName = defaultAddress.fullName || account.name;
@@ -115,21 +138,98 @@ export async function POST(req: NextRequest) {
 
   let itemsTotal = 0;
   const createdItems: any[] = [];
-  const usedWarehouses = new Set<string | 'default'>();
+  const shipmentsMap = new Map<
+    string,
+    { originCityName: string | null; originCityId: string | null; weight: number }
+  >();
+
   for (const it of items) {
-    const p = products.find(pp => pp.id === it.productId)!;
+    const p = products.find((pp) => pp.id === it.productId)!;
     const discountPercent = flashSaleMap.get(p.id);
     const unitPrice = discountPercent
       ? calculateFlashSalePrice(p.price, { discountPercent, startAt: now, endAt: now })
       : p.price;
     itemsTotal += unitPrice * it.qty;
     createdItems.push({ productId: p.id, sellerId: p.sellerId, qty: it.qty, price: unitPrice });
-    // @ts-ignore
-    usedWarehouses.add(p.warehouseId || 'default');
+
+    const shipmentKey = p.warehouseId ?? 'default';
+    const existing =
+      shipmentsMap.get(shipmentKey) ?? {
+        originCityName: null as string | null,
+        originCityId: null as string | null,
+        weight: 0,
+      };
+
+    if (!existing.originCityName) {
+      const warehouseCity = p.warehouse?.city?.trim();
+      if (warehouseCity) {
+        existing.originCityName = warehouseCity;
+      } else if (defaultOriginCityName) {
+        existing.originCityName = defaultOriginCityName;
+      }
+    }
+
+    if (!existing.originCityId && !p.warehouse?.city && defaultOriginCityId) {
+      existing.originCityId = defaultOriginCityId;
+    }
+
+    const quantity = Math.max(1, Number.isFinite(it.qty) ? it.qty : 1);
+    existing.weight += quantity * DEFAULT_ITEM_WEIGHT_GRAMS;
+    shipmentsMap.set(shipmentKey, existing);
   }
 
-  const shipments = Math.max(1, usedWarehouses.size);
-  const shippingCost = courier.cost * shipments;
+  const shipments = Math.max(1, shipmentsMap.size || 0);
+  let shippingCost = courier.fallbackCost * shipments;
+
+  const destinationCityId = await findCityIdByName({
+    cityName: shippingDestinationCity,
+    provinceName: shippingDestinationProvince,
+  });
+
+  if (destinationCityId) {
+    try {
+      let totalCost = 0;
+
+      for (const shipment of shipmentsMap.values()) {
+        let originCityId = shipment.originCityId;
+
+        if (!originCityId && shipment.originCityName) {
+          originCityId = await findCityIdByName({ cityName: shipment.originCityName });
+        }
+
+        if (!originCityId) {
+          throw new Error(
+            `Origin city ID not found for ${shipment.originCityName ?? 'default warehouse'}.`,
+          );
+        }
+
+        const costResults = await fetchRajaOngkirCost({
+          origin: originCityId,
+          destination: destinationCityId,
+          weight: shipment.weight || DEFAULT_ITEM_WEIGHT_GRAMS,
+          courier: courier.rajaOngkir.courier,
+        });
+
+        const courierResult = costResults.find(
+          (result) => result.code.toLowerCase() === courier.rajaOngkir.courier.toLowerCase(),
+        );
+        const service = courierResult?.costs.find(
+          (option) => option.service.toUpperCase() === courier.rajaOngkir.service,
+        );
+        const firstCost = service?.cost?.[0]?.value;
+
+        if (typeof firstCost !== 'number' || Number.isNaN(firstCost)) {
+          throw new Error('RajaOngkir did not return a valid cost for the selected service.');
+        }
+
+        totalCost += firstCost;
+      }
+
+      shippingCost = totalCost;
+    } catch (error) {
+      console.error('Failed to calculate RajaOngkir shipping cost', error);
+    }
+  }
 
   // Voucher
   let voucherDiscount = 0; let voucherUsed: string | null = null;

--- a/app/api/rajaongkir/cities/route.ts
+++ b/app/api/rajaongkir/cities/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+
+import { fetchRajaOngkir, RajaOngkirError } from "@/lib/rajaongkir";
+
+type CityResult = {
+  city_id: string;
+  city_name: string;
+  type: string;
+};
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const provinceId = searchParams.get("province");
+
+  if (!provinceId) {
+    return NextResponse.json(
+      { error: "Parameter province wajib diisi." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const results = await fetchRajaOngkir<CityResult[]>("city", {
+      province: provinceId,
+    });
+
+    const cities = results
+      .filter((city) => city?.city_id && city?.city_name)
+      .map((city) => ({
+        id: city.city_id,
+        name: city.city_name.trim(),
+        type: city.type.trim(),
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    return NextResponse.json(cities);
+  } catch (error) {
+    if (error instanceof RajaOngkirError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: error.statusCode >= 400 ? error.statusCode : 502 },
+      );
+    }
+
+    console.error("Failed to load cities from RajaOngkir", error);
+    return NextResponse.json(
+      { error: "Gagal memuat daftar kota." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/rajaongkir/provinces/route.ts
+++ b/app/api/rajaongkir/provinces/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+
+import { fetchRajaOngkir, RajaOngkirError } from "@/lib/rajaongkir";
+
+type ProvinceResult = {
+  province_id: string;
+  province: string;
+};
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const results = await fetchRajaOngkir<ProvinceResult[]>("province");
+    const provinces = results
+      .filter((province) => province?.province_id && province?.province)
+      .map((province) => ({
+        id: province.province_id,
+        name: province.province.trim(),
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    return NextResponse.json(provinces);
+  } catch (error) {
+    if (error instanceof RajaOngkirError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: error.statusCode >= 400 ? error.statusCode : 502 },
+      );
+    }
+
+    console.error("Failed to load provinces from RajaOngkir", error);
+    return NextResponse.json(
+      { error: "Gagal memuat daftar provinsi." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/rajaongkir/subdistricts/route.ts
+++ b/app/api/rajaongkir/subdistricts/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+
+import { fetchRajaOngkir, RajaOngkirError } from "@/lib/rajaongkir";
+
+type SubdistrictResult = {
+  subdistrict_id: string;
+  subdistrict_name: string;
+};
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const cityId = searchParams.get("city");
+
+  if (!cityId) {
+    return NextResponse.json(
+      { error: "Parameter city wajib diisi." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const results = await fetchRajaOngkir<SubdistrictResult[]>("subdistrict", {
+      city: cityId,
+    });
+
+    const subdistricts = results
+      .filter((subdistrict) => subdistrict?.subdistrict_id && subdistrict?.subdistrict_name)
+      .map((subdistrict) => ({
+        id: subdistrict.subdistrict_id,
+        name: subdistrict.subdistrict_name.trim(),
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    return NextResponse.json(subdistricts);
+  } catch (error) {
+    if (error instanceof RajaOngkirError) {
+      if (error.statusCode === 400 || error.statusCode === 403) {
+        return NextResponse.json(
+          { error: error.message },
+          { status: 501 },
+        );
+      }
+
+      return NextResponse.json(
+        { error: error.message },
+        { status: error.statusCode >= 400 ? error.statusCode : 502 },
+      );
+    }
+
+    console.error("Failed to load subdistricts from RajaOngkir", error);
+    return NextResponse.json(
+      { error: "Gagal memuat daftar kecamatan." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -233,14 +233,21 @@ export default function CheckoutPage() {
 
           <div>
             <label className="block text-sm mb-1">Kurir</label>
-            <select value={courier} onChange={(e)=>setCourier(e.target.value as keyof typeof COURIERS)} className="border rounded w-full px-3 py-2">
-              {Object.entries(COURIERS).map(([k,v]) => (
+            <select
+              value={courier}
+              onChange={(e) => setCourier(e.target.value as keyof typeof COURIERS)}
+              className="border rounded w-full px-3 py-2"
+            >
+              {Object.entries(COURIERS).map(([k, v]) => (
                 <option key={k} value={k}>
-                  {v.label} (Rp {new Intl.NumberFormat('id-ID').format(v.cost)})
+                  {v.label} (estimasi Rp {new Intl.NumberFormat('id-ID').format(v.fallbackCost)})
                 </option>
               ))}
             </select>
-            <p className="text-xs text-gray-500 mt-1">Ongkir dihitung per gudang (per-shipment) di server.</p>
+            <p className="text-xs text-gray-500 mt-1">
+              Ongkir final dihitung otomatis via RajaOngkir saat pesanan dibuat (per gudang). Estimasi di atas
+              digunakan jika RajaOngkir tidak tersedia.
+            </p>
           </div>
 
           <div>

--- a/components/AddressRegionFields.tsx
+++ b/components/AddressRegionFields.tsx
@@ -1,0 +1,433 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+type ProvinceOption = {
+  id: string;
+  name: string;
+};
+
+type CityOption = {
+  id: string;
+  name: string;
+  type: string;
+};
+
+type SubdistrictOption = {
+  id: string;
+  name: string;
+};
+
+type AddressRegionFieldsProps = {
+  idPrefix: string;
+  defaultProvince?: string;
+  defaultCity?: string;
+  defaultDistrict?: string;
+};
+
+const FIELD_CLASSNAME =
+  "w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30";
+
+function normalize(value: string) {
+  return value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+async function fetchJson<T>(input: string, signal: AbortSignal): Promise<T> {
+  const response = await fetch(input, { signal, cache: "no-store" });
+  if (!response.ok) {
+    let message = response.statusText;
+    try {
+      const body = (await response.json()) as { error?: string };
+      if (body?.error) {
+        message = body.error;
+      }
+    } catch {
+      // ignore JSON parsing errors
+    }
+    const error = new Error(message);
+    (error as Error & { status?: number }).status = response.status;
+    throw error;
+  }
+  return (await response.json()) as T;
+}
+
+export function AddressRegionFields({
+  idPrefix,
+  defaultProvince = "",
+  defaultCity = "",
+  defaultDistrict = "",
+}: AddressRegionFieldsProps) {
+  const normalizedDefaultProvince = useMemo(() => defaultProvince.trim(), [defaultProvince]);
+  const normalizedDefaultCity = useMemo(() => defaultCity.trim(), [defaultCity]);
+  const normalizedDefaultDistrict = useMemo(() => defaultDistrict.trim(), [defaultDistrict]);
+
+  const [provinceOptions, setProvinceOptions] = useState<ProvinceOption[]>([]);
+  const [provinceStatus, setProvinceStatus] = useState<"idle" | "loading" | "loaded" | "error">("idle");
+  const [provinceError, setProvinceError] = useState<string | null>(null);
+  const [provinceValue, setProvinceValue] = useState(normalizedDefaultProvince);
+  const [selectedProvinceId, setSelectedProvinceId] = useState<string | null>(null);
+
+  const [cityOptions, setCityOptions] = useState<CityOption[]>([]);
+  const [cityStatus, setCityStatus] = useState<"idle" | "loading" | "loaded" | "error">("idle");
+  const [cityError, setCityError] = useState<string | null>(null);
+  const [cityValue, setCityValue] = useState(normalizedDefaultCity);
+  const [selectedCityId, setSelectedCityId] = useState<string | null>(null);
+
+  const [subdistrictOptions, setSubdistrictOptions] = useState<SubdistrictOption[]>([]);
+  const [subdistrictStatus, setSubdistrictStatus] = useState<
+    "idle" | "loading" | "loaded" | "error" | "unsupported"
+  >(normalizedDefaultDistrict ? "idle" : "idle");
+  const [subdistrictError, setSubdistrictError] = useState<string | null>(null);
+  const [subdistrictValue, setSubdistrictValue] = useState(normalizedDefaultDistrict);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    async function loadProvinces() {
+      setProvinceStatus("loading");
+      try {
+        const data = await fetchJson<ProvinceOption[]>("/api/rajaongkir/provinces", controller.signal);
+        setProvinceOptions(data);
+        setProvinceStatus("loaded");
+        setProvinceError(null);
+      } catch (error) {
+        if ((error as Error).name === "AbortError") {
+          return;
+        }
+        console.error("Failed to fetch provinces", error);
+        setProvinceError("Gagal memuat provinsi. Silakan isi manual.");
+        setProvinceStatus("error");
+      }
+    }
+
+    void loadProvinces();
+
+    return () => {
+      controller.abort();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (provinceStatus !== "loaded") {
+      return;
+    }
+    if (!provinceValue) {
+      setSelectedProvinceId(null);
+      return;
+    }
+    const normalized = normalize(provinceValue);
+    const matched = provinceOptions.find((option) => normalize(option.name) === normalized);
+    setSelectedProvinceId(matched ? matched.id : null);
+  }, [provinceStatus, provinceOptions, provinceValue]);
+
+  useEffect(() => {
+    if (!selectedProvinceId) {
+      setCityOptions([]);
+      setCityStatus("idle");
+      setCityError(null);
+      setSelectedCityId(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    const provinceId = selectedProvinceId as string;
+
+    async function loadCities() {
+      setCityStatus("loading");
+      try {
+        const data = await fetchJson<CityOption[]>(
+          `/api/rajaongkir/cities?province=${encodeURIComponent(provinceId)}`,
+          controller.signal,
+        );
+        setCityOptions(data);
+        setCityStatus("loaded");
+        setCityError(null);
+      } catch (error) {
+        if ((error as Error).name === "AbortError") {
+          return;
+        }
+        console.error("Failed to fetch cities", error);
+        setCityError("Gagal memuat kota/kabupaten. Silakan isi manual.");
+        setCityStatus("error");
+      }
+    }
+
+    void loadCities();
+
+    return () => {
+      controller.abort();
+    };
+  }, [selectedProvinceId]);
+
+  useEffect(() => {
+    if (cityStatus !== "loaded") {
+      setSelectedCityId(null);
+      return;
+    }
+    if (!cityValue) {
+      setSelectedCityId(null);
+      return;
+    }
+    const normalized = normalize(cityValue);
+    const matched = cityOptions.find((option) => {
+      const displayName = `${option.type} ${option.name}`.replace(/\s+/g, " ").trim();
+      return normalize(displayName) === normalized || normalize(option.name) === normalized;
+    });
+    setSelectedCityId(matched ? matched.id : null);
+  }, [cityStatus, cityOptions, cityValue]);
+
+  useEffect(() => {
+    if (!selectedCityId) {
+      setSubdistrictOptions([]);
+      setSubdistrictStatus("idle");
+      setSubdistrictError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    const cityId = selectedCityId as string;
+
+    async function loadSubdistricts() {
+      setSubdistrictStatus("loading");
+      try {
+        const data = await fetch(`/api/rajaongkir/subdistricts?city=${encodeURIComponent(cityId)}`, {
+          signal: controller.signal,
+          cache: "no-store",
+        });
+
+        if (data.status === 501) {
+          let message = "Kecamatan tidak tersedia dari API. Isi manual.";
+          try {
+            const body = (await data.json()) as { error?: string };
+            if (body?.error) {
+              message = body.error;
+            }
+          } catch {
+            // ignore parsing error
+          }
+          setSubdistrictError(message);
+          setSubdistrictOptions([]);
+          setSubdistrictStatus("unsupported");
+          return;
+        }
+
+        if (!data.ok) {
+          let message = data.statusText;
+          try {
+            const body = (await data.json()) as { error?: string };
+            if (body?.error) {
+              message = body.error;
+            }
+          } catch {
+            // ignore
+          }
+          throw new Error(message);
+        }
+
+        const body = (await data.json()) as SubdistrictOption[];
+        setSubdistrictOptions(body);
+        setSubdistrictStatus("loaded");
+        setSubdistrictError(null);
+      } catch (error) {
+        if ((error as Error).name === "AbortError") {
+          return;
+        }
+        console.error("Failed to fetch subdistricts", error);
+        setSubdistrictError("Gagal memuat kecamatan. Silakan isi manual.");
+        setSubdistrictOptions([]);
+        setSubdistrictStatus("error");
+      }
+    }
+
+    void loadSubdistricts();
+
+    return () => {
+      controller.abort();
+    };
+  }, [selectedCityId]);
+
+  const provinceFallback = provinceStatus === "error";
+  const cityFallback = provinceFallback || cityStatus === "error";
+  const subdistrictFallback =
+    provinceFallback || cityFallback || subdistrictStatus === "error" || subdistrictStatus === "unsupported";
+
+  return (
+    <>
+      <div className="space-y-1">
+        <label htmlFor={`${idPrefix}-province`} className="text-sm font-medium text-gray-700">
+          Provinsi
+        </label>
+        {provinceFallback ? (
+          <>
+            <input
+              id={`${idPrefix}-province`}
+              name="province"
+              type="text"
+              required
+              defaultValue={provinceValue}
+              placeholder="Tulis provinsi"
+              className={FIELD_CLASSNAME}
+            />
+            {provinceError ? <p className="text-xs text-red-600">{provinceError}</p> : null}
+          </>
+        ) : (
+          <select
+            id={`${idPrefix}-province`}
+            name="province"
+            required
+            className={FIELD_CLASSNAME}
+            value={provinceValue}
+            onChange={(event) => {
+              const value = event.target.value;
+              setProvinceValue(value);
+              setCityValue("");
+              setSelectedCityId(null);
+              setSubdistrictValue("");
+              setSubdistrictOptions([]);
+              setSubdistrictStatus("idle");
+              setCityError(null);
+              setSubdistrictError(null);
+            }}
+            disabled={provinceStatus !== "loaded"}
+          >
+            <option value="">
+              {provinceStatus === "loading" ? "Memuat provinsi..." : "Pilih provinsi"}
+            </option>
+            {provinceValue &&
+            provinceOptions.every((option) => normalize(option.name) !== normalize(provinceValue)) ? (
+              <option value={provinceValue}>{provinceValue}</option>
+            ) : null}
+            {provinceOptions.map((province) => (
+              <option key={province.id} value={province.name} data-id={province.id}>
+                {province.name}
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      <div className="space-y-1">
+        <label htmlFor={`${idPrefix}-city`} className="text-sm font-medium text-gray-700">
+          Kota / Kabupaten
+        </label>
+        {cityFallback ? (
+          <>
+            <input
+              id={`${idPrefix}-city`}
+              name="city"
+              type="text"
+              required
+              defaultValue={cityValue}
+              placeholder="Tulis kota atau kabupaten"
+              className={FIELD_CLASSNAME}
+            />
+            {cityError ? <p className="text-xs text-red-600">{cityError}</p> : null}
+          </>
+        ) : (
+          <select
+            id={`${idPrefix}-city`}
+            name="city"
+            required
+            className={FIELD_CLASSNAME}
+            value={cityValue}
+            onChange={(event) => {
+              const value = event.target.value;
+              setCityValue(value);
+              setSubdistrictValue("");
+              setSubdistrictOptions([]);
+              setSubdistrictStatus("idle");
+              setSubdistrictError(null);
+            }}
+            disabled={provinceStatus !== "loaded" || !selectedProvinceId || cityStatus === "loading"}
+          >
+            <option value="">
+              {selectedProvinceId
+                ? cityStatus === "loading"
+                  ? "Memuat kota/kabupaten..."
+                  : "Pilih kota/kabupaten"
+                : "Pilih provinsi terlebih dahulu"}
+            </option>
+            {cityValue &&
+            cityOptions.every((option) => {
+              const displayName = `${option.type} ${option.name}`.replace(/\s+/g, " ").trim();
+              return (
+                normalize(displayName) !== normalize(cityValue) && normalize(option.name) !== normalize(cityValue)
+              );
+            }) ? (
+              <option value={cityValue}>{cityValue}</option>
+            ) : null}
+            {cityOptions.map((city) => {
+              const displayName = `${city.type} ${city.name}`.replace(/\s+/g, " ").trim();
+              return (
+                <option key={city.id} value={displayName} data-id={city.id}>
+                  {displayName}
+                </option>
+              );
+            })}
+          </select>
+        )}
+      </div>
+
+      <div className="space-y-1">
+        <label htmlFor={`${idPrefix}-district`} className="text-sm font-medium text-gray-700">
+          Kecamatan
+        </label>
+        {subdistrictFallback ? (
+          <>
+            <input
+              id={`${idPrefix}-district`}
+              name="district"
+              type="text"
+              required
+              defaultValue={subdistrictValue}
+              placeholder="Tulis kecamatan"
+              className={FIELD_CLASSNAME}
+            />
+            {subdistrictError ? <p className="text-xs text-red-600">{subdistrictError}</p> : null}
+          </>
+        ) : (
+          <select
+            id={`${idPrefix}-district`}
+            name="district"
+            required
+            className={FIELD_CLASSNAME}
+            value={subdistrictValue}
+            onChange={(event) => {
+              setSubdistrictValue(event.target.value);
+            }}
+            disabled={
+              provinceStatus !== "loaded" ||
+              !selectedProvinceId ||
+              !selectedCityId ||
+              subdistrictStatus === "loading"
+            }
+          >
+            <option value="">
+              {selectedCityId
+                ? subdistrictStatus === "loading"
+                  ? "Memuat kecamatan..."
+                  : "Pilih kecamatan"
+                : selectedProvinceId
+                ? "Pilih kota/kabupaten terlebih dahulu"
+                : "Pilih provinsi terlebih dahulu"}
+            </option>
+            {subdistrictValue &&
+            subdistrictOptions.every((option) => normalize(option.name) !== normalize(subdistrictValue)) ? (
+              <option value={subdistrictValue}>{subdistrictValue}</option>
+            ) : null}
+            {subdistrictOptions.map((subdistrict) => (
+              <option key={subdistrict.id} value={subdistrict.name}>
+                {subdistrict.name}
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+    </>
+  );
+}

--- a/lib/rajaongkir.ts
+++ b/lib/rajaongkir.ts
@@ -1,0 +1,257 @@
+const DEFAULT_BASE_URL = "https://api.rajaongkir.com/starter/";
+
+export class RajaOngkirError extends Error {
+  public readonly statusCode: number;
+
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.name = "RajaOngkirError";
+    this.statusCode = statusCode;
+  }
+}
+
+function getApiKey(): string {
+  const key = process.env.RAJAONGKIR_API_KEY;
+  if (!key) {
+    throw new RajaOngkirError(
+      "RAJAONGKIR_API_KEY is not configured in the environment.",
+      500,
+    );
+  }
+  return key;
+}
+
+function getBaseUrl(): string {
+  const base = process.env.RAJAONGKIR_API_BASE_URL?.trim();
+  if (!base) {
+    return DEFAULT_BASE_URL;
+  }
+  try {
+    const normalized = new URL(base);
+    if (!normalized.pathname.endsWith("/")) {
+      normalized.pathname = `${normalized.pathname}/`;
+    }
+    return normalized.toString();
+  } catch {
+    return DEFAULT_BASE_URL;
+  }
+}
+
+type RajaOngkirStatus = {
+  code: number;
+  description: string;
+};
+
+type RajaOngkirResponse<T> = {
+  rajaongkir?: {
+    status?: RajaOngkirStatus;
+    results?: T;
+  };
+};
+
+export type RajaOngkirProvince = {
+  province_id: string;
+  province: string;
+};
+
+export type RajaOngkirCity = {
+  city_id: string;
+  city_name: string;
+  type: string;
+  province_id: string;
+  province: string;
+  postal_code: string;
+};
+
+export type RajaOngkirCostResult = {
+  code: string;
+  name: string;
+  costs: {
+    service: string;
+    description: string;
+    cost: { value: number; etd: string; note: string }[];
+  }[];
+};
+
+function normalizeRegion(value: string) {
+  return value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9\s]/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function normalizeCity(value: string) {
+  return normalizeRegion(value)
+    .replace(/^(kota|kabupaten|kab|kodya|kotamadya)\s+/g, "")
+    .replace(/^administrasi\s+/g, "")
+    .trim();
+}
+
+let cachedCities: RajaOngkirCity[] | null = null;
+
+export async function fetchRajaOngkir<T>(
+  endpoint: string,
+  params: Record<string, string | number | undefined> = {},
+  init: RequestInit = {},
+): Promise<T> {
+  const baseUrl = getBaseUrl();
+  const url = new URL(endpoint.replace(/^\//, ""), baseUrl);
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined) continue;
+    url.searchParams.set(key, String(value));
+  }
+
+  const response = await fetch(url.toString(), {
+    ...init,
+    method: "GET",
+    headers: {
+      key: getApiKey(),
+      ...init.headers,
+    },
+    cache: "no-store",
+  });
+
+  const contentType = response.headers.get("content-type");
+  const isJson = contentType?.includes("application/json");
+
+  if (!isJson) {
+    if (!response.ok) {
+      throw new RajaOngkirError(response.statusText, response.status);
+    }
+    throw new RajaOngkirError("Unexpected response from RajaOngkir API.", 500);
+  }
+
+  const body = (await response.json()) as RajaOngkirResponse<T>;
+  const status = body.rajaongkir?.status;
+  const results = body.rajaongkir?.results;
+
+  if (!status) {
+    throw new RajaOngkirError("Missing status information from RajaOngkir API.", 500);
+  }
+
+  if (status.code !== 200) {
+    throw new RajaOngkirError(status.description ?? "RajaOngkir API error.", status.code);
+  }
+
+  if (results === undefined) {
+    throw new RajaOngkirError("Missing results in RajaOngkir API response.", 500);
+  }
+
+  return results;
+}
+
+async function getAllCities(): Promise<RajaOngkirCity[]> {
+  if (!cachedCities) {
+    cachedCities = await fetchRajaOngkir<RajaOngkirCity[]>("city");
+  }
+  return cachedCities;
+}
+
+type FindCityIdOptions = {
+  cityName: string | null | undefined;
+  provinceName?: string | null;
+};
+
+export async function findCityIdByName({
+  cityName,
+  provinceName,
+}: FindCityIdOptions): Promise<string | null> {
+  if (!cityName) {
+    return null;
+  }
+
+  const normalizedCity = normalizeCity(cityName);
+  const normalizedProvince = provinceName ? normalizeRegion(provinceName) : null;
+
+  if (!normalizedCity) {
+    return null;
+  }
+
+  const cities = await getAllCities();
+
+  for (const city of cities) {
+    if (normalizedProvince && normalizeRegion(city.province) !== normalizedProvince) {
+      continue;
+    }
+
+    const cityFull = normalizeCity(`${city.type} ${city.city_name}`);
+    const cityOnly = normalizeCity(city.city_name);
+
+    if (cityFull === normalizedCity || cityOnly === normalizedCity) {
+      return city.city_id;
+    }
+  }
+
+  return null;
+}
+
+type FetchCostParams = {
+  origin: string;
+  originType?: "city" | "subdistrict";
+  destination: string;
+  destinationType?: "city" | "subdistrict";
+  weight: number;
+  courier: string;
+};
+
+export async function fetchRajaOngkirCost({
+  origin,
+  originType = "city",
+  destination,
+  destinationType = "city",
+  weight,
+  courier,
+}: FetchCostParams): Promise<RajaOngkirCostResult[]> {
+  const baseUrl = getBaseUrl();
+  const url = new URL("cost", baseUrl);
+
+  const body = new URLSearchParams();
+  body.set("origin", origin);
+  body.set("originType", originType);
+  body.set("destination", destination);
+  body.set("destinationType", destinationType);
+  body.set("weight", String(Math.max(1, Math.min(30000, Math.round(weight)))));
+  body.set("courier", courier);
+
+  const response = await fetch(url.toString(), {
+    method: "POST",
+    headers: {
+      key: getApiKey(),
+      "content-type": "application/x-www-form-urlencoded",
+    },
+    body: body.toString(),
+    cache: "no-store",
+  });
+
+  const contentType = response.headers.get("content-type");
+  const isJson = contentType?.includes("application/json");
+
+  if (!isJson) {
+    if (!response.ok) {
+      throw new RajaOngkirError(response.statusText, response.status);
+    }
+    throw new RajaOngkirError("Unexpected response from RajaOngkir API.", 500);
+  }
+
+  const bodyJson = (await response.json()) as RajaOngkirResponse<RajaOngkirCostResult[]>;
+  const status = bodyJson.rajaongkir?.status;
+  const results = bodyJson.rajaongkir?.results;
+
+  if (!status) {
+    throw new RajaOngkirError("Missing status information from RajaOngkir API.", 500);
+  }
+
+  if (status.code !== 200) {
+    throw new RajaOngkirError(status.description ?? "RajaOngkir API error.", status.code);
+  }
+
+  if (!Array.isArray(results)) {
+    throw new RajaOngkirError("Missing results in RajaOngkir API response.", 500);
+  }
+
+  return results;
+}

--- a/lib/shipping.ts
+++ b/lib/shipping.ts
@@ -1,6 +1,39 @@
 export type CourierKey = 'JNE_REG' | 'JNT_REG' | 'SICEPAT_REG';
-export const COURIERS: Record<CourierKey, { label: string; cost: number }> = {
-  JNE_REG: { label: 'JNE Reguler', cost: 20000 },
-  JNT_REG: { label: 'J&T Reguler', cost: 22000 },
-  SICEPAT_REG: { label: 'SiCepat Reguler', cost: 21000 },
+
+export type CourierConfig = {
+  label: string;
+  /**
+   * Used when RajaOngkir cost lookup fails so checkout still works.
+   */
+  fallbackCost: number;
+  rajaOngkir: {
+    /** RajaOngkir courier code */
+    courier: string;
+    /** RajaOngkir service code */
+    service: string;
+  };
 };
+
+export const COURIERS: Record<CourierKey, CourierConfig> = {
+  JNE_REG: {
+    label: 'JNE Reguler',
+    fallbackCost: 20000,
+    rajaOngkir: { courier: 'jne', service: 'REG' },
+  },
+  JNT_REG: {
+    label: 'J&T Reguler',
+    fallbackCost: 22000,
+    rajaOngkir: { courier: 'jnt', service: 'EZ' },
+  },
+  SICEPAT_REG: {
+    label: 'SiCepat Reguler',
+    fallbackCost: 21000,
+    rajaOngkir: { courier: 'sicepat', service: 'REG' },
+  },
+};
+
+/**
+ * Rough default weight per item (grams) when product weight is unknown.
+ * RajaOngkir Starter supports maximum 30.000 gram per request.
+ */
+export const DEFAULT_ITEM_WEIGHT_GRAMS = 1000;


### PR DESCRIPTION
## Summary
- replace static courier fees with RajaOngkir cost lookups during checkout while keeping a per-warehouse fallback estimate
- expose RajaOngkir helpers to resolve city IDs/costs and enrich courier metadata and default item weights
- refresh the checkout copy and README to highlight the dynamic shipping integration and new origin city environment variables

## Testing
- CI=1 npm run build *(Prisma migrate deploy skipped because the shared database is unreachable, Next.js build completed)*

------
https://chatgpt.com/codex/tasks/task_e_68e50396659c832086e2c3afaa67e04b