### PR TITLE
Implement secure password reset via emailed link

### DIFF
--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -1,18 +1,39 @@
 import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/lib/prisma";
 import bcrypt from "bcryptjs";
 
+import { sendPasswordResetSuccessEmail } from "@/lib/email";
+import { prisma } from "@/lib/prisma";
+import { findValidPasswordResetToken } from "@/lib/password-reset";
+
 function buildErrorResponse() {
-  return NextResponse.json({ error: "OTP atau email tidak valid." }, { status: 400 });
+  return NextResponse.json(
+    { error: "Token reset password tidak valid atau sudah tidak berlaku." },
+    { status: 400 },
+  );
+}
+
+export async function GET(req: NextRequest) {
+  const token = req.nextUrl.searchParams.get("token") ?? "";
+
+  if (!token) {
+    return buildErrorResponse();
+  }
+
+  const resetToken = await findValidPasswordResetToken(token);
+
+  if (!resetToken) {
+    return buildErrorResponse();
+  }
+
+  return NextResponse.json({ message: "Token valid." });
 }
 
 export async function POST(req: NextRequest) {
   const form = await req.formData();
-  const email = String(form.get("email") || "").toLowerCase().trim();
-  const otp = String(form.get("otp") || "").trim();
+  const token = String(form.get("token") || "").trim();
   const password = String(form.get("password") || "");
 
-  if (!email || !otp || !password) {
+  if (!token || !password) {
     return NextResponse.json({ error: "Mohon lengkapi semua data." }, { status: 400 });
   }
 
@@ -20,46 +41,65 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Password baru minimal 8 karakter." }, { status: 400 });
   }
 
-  const user = await prisma.user.findUnique({ where: { email } });
-  if (!user) {
-    return buildErrorResponse();
-  }
+  const resetToken = await findValidPasswordResetToken(token);
 
-  const activeToken = await prisma.passwordResetToken.findFirst({
-    where: {
-      userId: user.id,
-      usedAt: null,
-    },
-    orderBy: { createdAt: "desc" },
-  });
-
-  if (!activeToken || activeToken.expiresAt < new Date()) {
-    return buildErrorResponse();
-  }
-
-  const matches = await bcrypt.compare(otp, activeToken.otpHash);
-  if (!matches) {
+  if (!resetToken) {
     return buildErrorResponse();
   }
 
   const newPasswordHash = await bcrypt.hash(password, 10);
+  const now = new Date();
 
-  await prisma.$transaction([
-    prisma.user.update({
-      where: { id: user.id },
-      data: { passwordHash: newPasswordHash },
-    }),
-    prisma.passwordResetToken.update({
-      where: { id: activeToken.id },
-      data: { usedAt: new Date() },
-    }),
-    prisma.passwordResetToken.deleteMany({
-      where: {
-        userId: user.id,
-        id: { not: activeToken.id },
-      },
-    }),
-  ]);
+  try {
+    await prisma.$transaction(async (tx) => {
+      await tx.user.update({
+        where: { id: resetToken.userId },
+        data: { passwordHash: newPasswordHash },
+      });
+
+      const updateTokenResult = await tx.passwordResetToken.updateMany({
+        where: {
+          tokenHash: resetToken.tokenHash,
+          usedAt: null,
+          expiresAt: { gt: now },
+        },
+        data: { usedAt: now },
+      });
+
+      if (updateTokenResult.count === 0) {
+        throw new Error("PASSWORD_RESET_TOKEN_ALREADY_USED");
+      }
+
+      await tx.passwordResetToken.deleteMany({
+        where: {
+          userId: resetToken.userId,
+          tokenHash: { not: resetToken.tokenHash },
+        },
+      });
+    });
+  } catch (transactionError) {
+    if (
+      transactionError instanceof Error &&
+      transactionError.message === "PASSWORD_RESET_TOKEN_ALREADY_USED"
+    ) {
+      return buildErrorResponse();
+    }
+
+    console.error("Gagal menyelesaikan transaksi reset password", transactionError);
+    return NextResponse.json(
+      { error: "Terjadi kesalahan saat memperbarui password. Silakan coba lagi." },
+      { status: 500 },
+    );
+  }
+
+  try {
+    await sendPasswordResetSuccessEmail({
+      email: resetToken.user.email,
+      name: resetToken.user.name,
+    });
+  } catch (emailError) {
+    console.error("Gagal mengirim email konfirmasi reset password", emailError);
+  }
 
   return NextResponse.json({ message: "Password berhasil diperbarui. Silakan login kembali." });
 }

--- a/app/seller/forgot-password/page.tsx
+++ b/app/seller/forgot-password/page.tsx
@@ -10,7 +10,7 @@ export default function SellerForgotPasswordPage() {
     <div className="mx-auto max-w-md rounded border bg-white p-6 shadow-sm">
       <h1 className="text-xl font-semibold text-gray-800">Lupa Password</h1>
       <p className="mt-2 text-sm text-gray-600">
-        Masukkan email akun seller Anda. Kami akan mengirim kode OTP untuk reset password.
+        Masukkan email akun seller Anda. Kami akan mengirim tautan reset password yang berlaku selama 30 menit.
       </p>
       <div className="mt-4">
         <ForgotPasswordForm />

--- a/app/seller/reset-password/page.tsx
+++ b/app/seller/reset-password/page.tsx
@@ -1,19 +1,41 @@
 import type { Metadata } from "next";
 import ResetPasswordForm from "@/components/ResetPasswordForm";
+import { findValidPasswordResetToken } from "@/lib/password-reset";
 
 export const metadata: Metadata = {
   title: "Reset Password Seller",
 };
 
-export default function SellerResetPasswordPage() {
+type SellerResetPasswordPageProps = {
+  searchParams?: Record<string, string | string[] | undefined>;
+};
+
+export default async function SellerResetPasswordPage({ searchParams }: SellerResetPasswordPageProps) {
+  const tokenParam = searchParams?.token;
+  const token = Array.isArray(tokenParam) ? tokenParam[0] : tokenParam ?? null;
+
+  let isTokenValid = false;
+  let invalidReason: string | undefined;
+
+  if (token) {
+    const resetToken = await findValidPasswordResetToken(token);
+    if (resetToken) {
+      isTokenValid = true;
+    } else {
+      invalidReason = "Token reset password tidak valid atau sudah kedaluwarsa.";
+    }
+  } else {
+    invalidReason = "Token reset password tidak ditemukan. Gunakan tautan terbaru dari email Anda.";
+  }
+
   return (
     <div className="mx-auto max-w-md rounded border bg-white p-6 shadow-sm">
       <h1 className="text-xl font-semibold text-gray-800">Reset Password</h1>
       <p className="mt-2 text-sm text-gray-600">
-        Masukkan email, kode OTP yang dikirim ke email Anda, dan password baru untuk menyelesaikan proses reset.
+        Masukkan password baru Anda. Tautan reset hanya berlaku selama 30 menit dan akan menjadi tidak valid setelah digunakan.
       </p>
       <div className="mt-4">
-        <ResetPasswordForm />
+        <ResetPasswordForm token={token} isTokenValid={isTokenValid} invalidReason={invalidReason} />
       </div>
       <div className="mt-6 text-center text-sm text-gray-600">
         Sudah selesai? <a className="font-semibold text-indigo-600 hover:underline" href="/seller/login">Kembali ke login</a>

--- a/components/ForgotPasswordForm.tsx
+++ b/components/ForgotPasswordForm.tsx
@@ -23,7 +23,7 @@ export default function ForgotPasswordForm() {
       const body = await response.json().catch(() => ({}));
 
       if (response.ok) {
-        setMessage(String(body.message ?? 'Kami telah mengirim OTP reset password apabila email terdaftar.'));
+        setMessage(String(body.message ?? 'Kami telah mengirim tautan reset password apabila email terdaftar.'));
         form.reset();
       } else {
         setError(String(body.message ?? body.error ?? 'Terjadi kesalahan. Coba lagi.'));
@@ -48,12 +48,12 @@ export default function ForgotPasswordForm() {
         className="w-full rounded bg-indigo-600 py-2 text-white hover:bg-indigo-700 disabled:opacity-50"
         disabled={isPending}
       >
-        {isPending ? 'Mengirim OTP...' : 'Kirim OTP Reset Password'}
+        {isPending ? 'Mengirim tautan...' : 'Kirim Link Reset Password'}
       </button>
       {message && <p className="rounded bg-green-50 px-3 py-2 text-sm text-green-700">{message}</p>}
       {error && <p className="rounded bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>}
       <p className="text-sm text-gray-600">
-        Kami akan mengirim kode OTP ke email Anda jika terdaftar. Gunakan kode tersebut untuk membuat password baru.
+        Kami akan mengirim tautan reset password ke email Anda jika terdaftar. Gunakan tautan tersebut untuk membuat password baru.
       </p>
     </form>
   );

--- a/components/ResetPasswordForm.tsx
+++ b/components/ResetPasswordForm.tsx
@@ -2,13 +2,28 @@
 
 import { FormEvent, useState, useTransition } from 'react';
 
-export default function ResetPasswordForm() {
-  const [error, setError] = useState<string | null>(null);
+type ResetPasswordFormProps = {
+  token: string | null;
+  isTokenValid: boolean;
+  invalidReason?: string;
+};
+
+export default function ResetPasswordForm({ token, isTokenValid, invalidReason }: ResetPasswordFormProps) {
+  const [error, setError] = useState<string | null>(
+    isTokenValid ? null : invalidReason ?? 'Token reset password tidak valid atau sudah tidak berlaku.',
+  );
   const [message, setMessage] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+
+    if (!token || !isTokenValid) {
+      setMessage(null);
+      setError('Token reset password tidak valid atau sudah tidak berlaku.');
+      return;
+    }
+
     const form = event.currentTarget;
     const formData = new FormData(form);
     const password = String(formData.get('password') ?? '');
@@ -33,36 +48,14 @@ export default function ResetPasswordForm() {
         setMessage(String(body.message ?? 'Password berhasil diperbarui.'));
         form.reset();
       } else {
-        setError(String(body.error ?? body.message ?? 'OTP atau email tidak valid.'));
+        setError(String(body.error ?? body.message ?? 'Token reset password tidak valid atau sudah tidak berlaku.'));
       }
     });
   };
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
-      <div>
-        <label className="block text-sm font-medium text-gray-700">Email</label>
-        <input
-          type="email"
-          name="email"
-          required
-          className="mt-1 w-full rounded border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-          placeholder="email yang terdaftar"
-        />
-      </div>
-      <div>
-        <label className="block text-sm font-medium text-gray-700">Kode OTP</label>
-        <input
-          type="text"
-          name="otp"
-          inputMode="numeric"
-          pattern="[0-9]{6}"
-          maxLength={6}
-          required
-          className="mt-1 w-full rounded border px-3 py-2 tracking-widest focus:outline-none focus:ring-2 focus:ring-indigo-500"
-          placeholder="6 digit kode"
-        />
-      </div>
+      <input type="hidden" name="token" value={token ?? ''} />
       <div>
         <label className="block text-sm font-medium text-gray-700">Password Baru</label>
         <input
@@ -88,14 +81,14 @@ export default function ResetPasswordForm() {
       <button
         type="submit"
         className="w-full rounded bg-indigo-600 py-2 text-white hover:bg-indigo-700 disabled:opacity-50"
-        disabled={isPending}
+        disabled={isPending || !token || !isTokenValid}
       >
         {isPending ? 'Memproses...' : 'Reset Password'}
       </button>
       {message && <p className="rounded bg-green-50 px-3 py-2 text-sm text-green-700">{message}</p>}
       {error && <p className="rounded bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>}
       <p className="text-sm text-gray-600">
-        Pastikan Anda menggunakan password yang kuat dan tidak membagikan kode OTP kepada siapapun.
+        Pastikan Anda menggunakan password yang kuat dan tidak membagikan tautan reset kepada siapapun.
       </p>
     </form>
   );

--- a/lib/password-reset.ts
+++ b/lib/password-reset.ts
@@ -1,0 +1,36 @@
+import { createHash, randomBytes } from "crypto";
+
+import { prisma } from "@/lib/prisma";
+
+export const PASSWORD_RESET_TOKEN_EXPIRATION_MINUTES = 30;
+
+export function generatePasswordResetToken() {
+  const token = randomBytes(32).toString("hex");
+  const tokenHash = hashPasswordResetToken(token);
+  const expiresAt = new Date(
+    Date.now() + PASSWORD_RESET_TOKEN_EXPIRATION_MINUTES * 60 * 1000,
+  );
+
+  return { token, tokenHash, expiresAt };
+}
+
+export function hashPasswordResetToken(token: string) {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+export async function findValidPasswordResetToken(token: string) {
+  if (!token) return null;
+
+  const tokenHash = hashPasswordResetToken(token);
+
+  const resetToken = await prisma.passwordResetToken.findUnique({
+    where: { tokenHash },
+    include: { user: { select: { id: true, email: true, name: true } } },
+  });
+
+  if (!resetToken) return null;
+  if (resetToken.usedAt) return null;
+  if (resetToken.expiresAt < new Date()) return null;
+
+  return resetToken;
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -251,7 +251,7 @@ model PasswordResetToken {
   id        String   @id @default(cuid())
   userId    String
   user      User     @relation(fields: [userId], references: [id])
-  otpHash   String
+  tokenHash String   @unique
   expiresAt DateTime
   usedAt    DateTime?
   createdAt DateTime @default(now())


### PR DESCRIPTION
## Summary
- replace the OTP-based password reset flow with single-use hashed tokens that are delivered through an emailed reset link
- add shared password reset helpers plus email templates for sending the link and success confirmation
- refresh the seller-facing forgot/reset password pages to drive the new link-based experience

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68e5387986808320a4c2278064dc024d