### PR TITLE
Implement secure password reset via emailed link and seller origin address management

### DIFF
--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -1,18 +1,39 @@
 import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/lib/prisma";
 import bcrypt from "bcryptjs";
 
+import { sendPasswordResetSuccessEmail } from "@/lib/email";
+import { prisma } from "@/lib/prisma";
+import { findValidPasswordResetToken } from "@/lib/password-reset";
+
 function buildErrorResponse() {
-  return NextResponse.json({ error: "OTP atau email tidak valid." }, { status: 400 });
+  return NextResponse.json(
+    { error: "Token reset password tidak valid atau sudah tidak berlaku." },
+    { status: 400 },
+  );
+}
+
+export async function GET(req: NextRequest) {
+  const token = req.nextUrl.searchParams.get("token") ?? "";
+
+  if (!token) {
+    return buildErrorResponse();
+  }
+
+  const resetToken = await findValidPasswordResetToken(token);
+
+  if (!resetToken) {
+    return buildErrorResponse();
+  }
+
+  return NextResponse.json({ message: "Token valid." });
 }
 
 export async function POST(req: NextRequest) {
   const form = await req.formData();
-  const email = String(form.get("email") || "").toLowerCase().trim();
-  const otp = String(form.get("otp") || "").trim();
+  const token = String(form.get("token") || "").trim();
   const password = String(form.get("password") || "");
 
-  if (!email || !otp || !password) {
+  if (!token || !password) {
     return NextResponse.json({ error: "Mohon lengkapi semua data." }, { status: 400 });
   }
 
@@ -20,46 +41,65 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Password baru minimal 8 karakter." }, { status: 400 });
   }
 
-  const user = await prisma.user.findUnique({ where: { email } });
-  if (!user) {
-    return buildErrorResponse();
-  }
+  const resetToken = await findValidPasswordResetToken(token);
 
-  const activeToken = await prisma.passwordResetToken.findFirst({
-    where: {
-      userId: user.id,
-      usedAt: null,
-    },
-    orderBy: { createdAt: "desc" },
-  });
-
-  if (!activeToken || activeToken.expiresAt < new Date()) {
-    return buildErrorResponse();
-  }
-
-  const matches = await bcrypt.compare(otp, activeToken.otpHash);
-  if (!matches) {
+  if (!resetToken) {
     return buildErrorResponse();
   }
 
   const newPasswordHash = await bcrypt.hash(password, 10);
+  const now = new Date();
 
-  await prisma.$transaction([
-    prisma.user.update({
-      where: { id: user.id },
-      data: { passwordHash: newPasswordHash },
-    }),
-    prisma.passwordResetToken.update({
-      where: { id: activeToken.id },
-      data: { usedAt: new Date() },
-    }),
-    prisma.passwordResetToken.deleteMany({
-      where: {
-        userId: user.id,
-        id: { not: activeToken.id },
-      },
-    }),
-  ]);
+  try {
+    await prisma.$transaction(async (tx) => {
+      await tx.user.update({
+        where: { id: resetToken.userId },
+        data: { passwordHash: newPasswordHash },
+      });
+
+      const updateTokenResult = await tx.passwordResetToken.updateMany({
+        where: {
+          tokenHash: resetToken.tokenHash,
+          usedAt: null,
+          expiresAt: { gt: now },
+        },
+        data: { usedAt: now },
+      });
+
+      if (updateTokenResult.count === 0) {
+        throw new Error("PASSWORD_RESET_TOKEN_ALREADY_USED");
+      }
+
+      await tx.passwordResetToken.deleteMany({
+        where: {
+          userId: resetToken.userId,
+          tokenHash: { not: resetToken.tokenHash },
+        },
+      });
+    });
+  } catch (transactionError) {
+    if (
+      transactionError instanceof Error &&
+      transactionError.message === "PASSWORD_RESET_TOKEN_ALREADY_USED"
+    ) {
+      return buildErrorResponse();
+    }
+
+    console.error("Gagal menyelesaikan transaksi reset password", transactionError);
+    return NextResponse.json(
+      { error: "Terjadi kesalahan saat memperbarui password. Silakan coba lagi." },
+      { status: 500 },
+    );
+  }
+
+  try {
+    await sendPasswordResetSuccessEmail({
+      email: resetToken.user.email,
+      name: resetToken.user.name,
+    });
+  } catch (emailError) {
+    console.error("Gagal mengirim email konfirmasi reset password", emailError);
+  }
 
   return NextResponse.json({ message: "Password berhasil diperbarui. Silakan login kembali." });
 }

--- a/app/api/seller/store/address/route.ts
+++ b/app/api/seller/store/address/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getIronSession } from "iron-session";
+
+import { prisma } from "@/lib/prisma";
+import { sessionOptions, type SessionUser } from "@/lib/session";
+
+export const runtime = "nodejs";
+
+export async function POST(req: NextRequest) {
+  const formData = await req.formData();
+
+  const redirectToRaw = formData.get("redirectTo");
+  const addressLineRaw = formData.get("addressLine");
+  const provinceRaw = formData.get("province");
+  const cityRaw = formData.get("city");
+  const districtRaw = formData.get("district");
+  const postalCodeRaw = formData.get("postalCode");
+  const originCityIdRaw = formData.get("originCityId");
+
+  const res = new NextResponse();
+  const session = await getIronSession<{ user?: SessionUser }>(req, res, sessionOptions);
+  const user = session.user;
+
+  let redirectUrl: URL;
+  try {
+    redirectUrl = new URL(typeof redirectToRaw === "string" ? redirectToRaw : "/seller/settings", req.url);
+  } catch {
+    redirectUrl = new URL("/seller/settings", req.url);
+  }
+
+  if (redirectUrl.origin !== new URL(req.url).origin) {
+    redirectUrl = new URL("/seller/settings", req.url);
+  }
+
+  if (!user) {
+    return NextResponse.redirect(new URL("/seller/login", req.url));
+  }
+
+  const province = typeof provinceRaw === "string" ? provinceRaw.trim() : "";
+  const city = typeof cityRaw === "string" ? cityRaw.trim() : "";
+  const district = typeof districtRaw === "string" ? districtRaw.trim() : "";
+  const postalCode = typeof postalCodeRaw === "string" ? postalCodeRaw.trim() : "";
+  const addressLine = typeof addressLineRaw === "string" ? addressLineRaw.trim() : "";
+  const originCityId = typeof originCityIdRaw === "string" ? originCityIdRaw.trim() : "";
+
+  if (!province || !city) {
+    redirectUrl.searchParams.set(
+      "addressError",
+      "Provinsi dan kota asal wajib diisi untuk menghitung ongkir otomatis.",
+    );
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  const account = await prisma.user.findUnique({
+    where: { id: user.id },
+    select: { isBanned: true, sellerOnboardingStatus: true },
+  });
+
+  if (!account) {
+    redirectUrl.searchParams.set("addressError", "Akun tidak ditemukan.");
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  if (account.isBanned) {
+    return NextResponse.redirect(new URL("/seller/login?error=banned", req.url));
+  }
+
+  if (account.sellerOnboardingStatus !== "ACTIVE") {
+    redirectUrl.searchParams.set(
+      "addressError",
+      "Aktifkan toko Anda melalui onboarding sebelum mengubah alamat toko.",
+    );
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  await prisma.user.update({
+    where: { id: user.id },
+    data: {
+      storeAddressLine: addressLine || null,
+      storeProvince: province,
+      storeCity: city,
+      storeDistrict: district || null,
+      storePostalCode: postalCode || null,
+      storeOriginCityId: originCityId || null,
+    },
+  });
+
+  redirectUrl.searchParams.delete("addressError");
+  redirectUrl.searchParams.set("addressUpdated", "1");
+
+  const response = NextResponse.redirect(redirectUrl);
+
+  res.headers.forEach((value, key) => {
+    if (key.toLowerCase() === "set-cookie") {
+      response.headers.append(key, value);
+    }
+  });
+
+  return response;
+}

--- a/app/seller/dashboard/page.tsx
+++ b/app/seller/dashboard/page.tsx
@@ -10,7 +10,16 @@ export default async function Dashboard() {
 
   const account = await prisma.user.findUnique({
     where: { id: user.id },
-    select: { isBanned: true, storeIsOnline: true, name: true, slug: true, sellerOnboardingStatus: true },
+    select: {
+      isBanned: true,
+      storeIsOnline: true,
+      name: true,
+      slug: true,
+      sellerOnboardingStatus: true,
+      storeCity: true,
+      storeProvince: true,
+      storeAddressLine: true,
+    },
   });
 
   if (!account || account.isBanned) {
@@ -48,6 +57,10 @@ export default async function Dashboard() {
   const storeIsOnline = account.storeIsOnline ?? false;
   const storeName = account.name;
   const storeSlug = account.slug;
+  const storeCity = account.storeCity?.trim() ?? "";
+  const storeProvince = account.storeProvince?.trim() ?? "";
+  const storeAddressLine = account.storeAddressLine?.trim() ?? "";
+  const hasStoreOrigin = Boolean(storeCity);
 
   const [pcount, orders, revenue] = await Promise.all([
     prisma.product.count({ where: { sellerId: user.id } }),
@@ -58,13 +71,30 @@ export default async function Dashboard() {
   return (
     <div>
       <h1 className="text-2xl font-semibold mb-4">Dashboard Seller</h1>
-      <div className="bg-white border rounded p-4 mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-        <div className="space-y-1">
-          <h2 className="font-semibold text-lg">Profil Toko</h2>
-          <div className="text-sm text-gray-600">
-            <div className="font-medium text-gray-900">{storeName}</div>
-            <div className="text-xs text-gray-500">Alamat etalase: https://akay.id/s/{storeSlug}</div>
+      <div className="bg-white border rounded p-4 mb-6 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div className="space-y-3">
+          <div>
+            <h2 className="font-semibold text-lg">Profil Toko</h2>
+            <div className="text-sm text-gray-600">
+              <div className="font-medium text-gray-900">{storeName}</div>
+              <div className="text-xs text-gray-500">Alamat etalase: https://akay.id/s/{storeSlug}</div>
+            </div>
           </div>
+          {hasStoreOrigin ? (
+            <div className="text-sm text-gray-600">
+              <div className="font-medium text-gray-900">Alamat pengiriman toko</div>
+              <p>
+                {[storeAddressLine, storeCity, storeProvince]
+                  .filter((part) => part && part.length > 0)
+                  .join(", ")}
+              </p>
+            </div>
+          ) : (
+            <div className="rounded border border-amber-200 bg-amber-50 p-3 text-xs text-amber-700">
+              Lengkapi alamat toko Anda agar ongkir otomatis dapat menggunakan kota asal toko saat produk belum diatur ke
+              gudang tertentu.
+            </div>
+          )}
           <a className="text-sm font-semibold text-[#f53d2d] hover:text-[#d63b22]" href="/seller/settings">
             Atur nama &amp; alamat toko →
           </a>

--- a/app/seller/forgot-password/page.tsx
+++ b/app/seller/forgot-password/page.tsx
@@ -10,7 +10,7 @@ export default function SellerForgotPasswordPage() {
     <div className="mx-auto max-w-md rounded border bg-white p-6 shadow-sm">
       <h1 className="text-xl font-semibold text-gray-800">Lupa Password</h1>
       <p className="mt-2 text-sm text-gray-600">
-        Masukkan email akun seller Anda. Kami akan mengirim kode OTP untuk reset password.
+        Masukkan email akun seller Anda. Kami akan mengirim tautan reset password yang berlaku selama 30 menit.
       </p>
       <div className="mt-4">
         <ForgotPasswordForm />

--- a/app/seller/reset-password/page.tsx
+++ b/app/seller/reset-password/page.tsx
@@ -1,19 +1,41 @@
 import type { Metadata } from "next";
 import ResetPasswordForm from "@/components/ResetPasswordForm";
+import { findValidPasswordResetToken } from "@/lib/password-reset";
 
 export const metadata: Metadata = {
   title: "Reset Password Seller",
 };
 
-export default function SellerResetPasswordPage() {
+type SellerResetPasswordPageProps = {
+  searchParams?: Record<string, string | string[] | undefined>;
+};
+
+export default async function SellerResetPasswordPage({ searchParams }: SellerResetPasswordPageProps) {
+  const tokenParam = searchParams?.token;
+  const token = Array.isArray(tokenParam) ? tokenParam[0] : tokenParam ?? null;
+
+  let isTokenValid = false;
+  let invalidReason: string | undefined;
+
+  if (token) {
+    const resetToken = await findValidPasswordResetToken(token);
+    if (resetToken) {
+      isTokenValid = true;
+    } else {
+      invalidReason = "Token reset password tidak valid atau sudah kedaluwarsa.";
+    }
+  } else {
+    invalidReason = "Token reset password tidak ditemukan. Gunakan tautan terbaru dari email Anda.";
+  }
+
   return (
     <div className="mx-auto max-w-md rounded border bg-white p-6 shadow-sm">
       <h1 className="text-xl font-semibold text-gray-800">Reset Password</h1>
       <p className="mt-2 text-sm text-gray-600">
-        Masukkan email, kode OTP yang dikirim ke email Anda, dan password baru untuk menyelesaikan proses reset.
+        Masukkan password baru Anda. Tautan reset hanya berlaku selama 30 menit dan akan menjadi tidak valid setelah digunakan.
       </p>
       <div className="mt-4">
-        <ResetPasswordForm />
+        <ResetPasswordForm token={token} isTokenValid={isTokenValid} invalidReason={invalidReason} />
       </div>
       <div className="mt-6 text-center text-sm text-gray-600">
         Sudah selesai? <a className="font-semibold text-indigo-600 hover:underline" href="/seller/login">Kembali ke login</a>

--- a/app/seller/settings/page.tsx
+++ b/app/seller/settings/page.tsx
@@ -20,7 +20,18 @@ export default async function SellerSettings({ searchParams }: SettingsPageProps
 
   const account = await prisma.user.findUnique({
     where: { id: user.id },
-    select: { name: true, slug: true, isBanned: true, sellerOnboardingStatus: true },
+    select: {
+      name: true,
+      slug: true,
+      isBanned: true,
+      sellerOnboardingStatus: true,
+      storeAddressLine: true,
+      storeProvince: true,
+      storeCity: true,
+      storeDistrict: true,
+      storePostalCode: true,
+      storeOriginCityId: true,
+    },
   });
 
   if (!account) {
@@ -59,6 +70,8 @@ export default async function SellerSettings({ searchParams }: SettingsPageProps
 
   const errorMessage = typeof searchParams?.error === "string" ? searchParams?.error : null;
   const successMessage = searchParams?.updated === "1";
+  const addressError = typeof searchParams?.addressError === "string" ? searchParams.addressError : null;
+  const addressSuccess = searchParams?.addressUpdated === "1";
 
   return (
     <div className="space-y-6">
@@ -118,6 +131,128 @@ export default async function SellerSettings({ searchParams }: SettingsPageProps
               Simpan perubahan
             </button>
             <span className="text-xs text-gray-500">Perubahan dapat memerlukan waktu beberapa menit untuk muncul di hasil pencarian.</span>
+          </div>
+        </form>
+      </div>
+
+      <div className="rounded border bg-white p-6 shadow-sm space-y-4">
+        <div>
+          <h2 className="text-lg font-semibold">Alamat Toko</h2>
+          <p className="text-sm text-gray-600">
+            Alamat ini digunakan sebagai kota asal pengiriman default ketika produk belum terhubung ke gudang tertentu.
+          </p>
+        </div>
+
+        {addressError ? (
+          <div className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">{addressError}</div>
+        ) : null}
+
+        {addressSuccess ? (
+          <div className="rounded border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-700">
+            Alamat toko berhasil diperbarui.
+          </div>
+        ) : null}
+
+        <form method="POST" action="/api/seller/store/address" className="space-y-4">
+          <input type="hidden" name="redirectTo" value="/seller/settings" />
+          <div className="space-y-1">
+            <label htmlFor="storeAddressLine" className="text-sm font-medium text-gray-700">
+              Alamat lengkap
+            </label>
+            <textarea
+              id="storeAddressLine"
+              name="addressLine"
+              defaultValue={account.storeAddressLine ?? ""}
+              placeholder="Contoh: Jl. Melati No. 10, Blok B"
+              rows={3}
+              className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/40"
+            />
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-1">
+              <label htmlFor="storeProvince" className="text-sm font-medium text-gray-700">
+                Provinsi<span className="text-red-500">*</span>
+              </label>
+              <input
+                id="storeProvince"
+                name="province"
+                type="text"
+                required
+                defaultValue={account.storeProvince ?? ""}
+                placeholder="Contoh: Jawa Barat"
+                className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/40"
+              />
+            </div>
+            <div className="space-y-1">
+              <label htmlFor="storeCity" className="text-sm font-medium text-gray-700">
+                Kota / Kabupaten<span className="text-red-500">*</span>
+              </label>
+              <input
+                id="storeCity"
+                name="city"
+                type="text"
+                required
+                defaultValue={account.storeCity ?? ""}
+                placeholder="Contoh: Bandung"
+                className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/40"
+              />
+            </div>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-1">
+              <label htmlFor="storeDistrict" className="text-sm font-medium text-gray-700">
+                Kecamatan
+              </label>
+              <input
+                id="storeDistrict"
+                name="district"
+                type="text"
+                defaultValue={account.storeDistrict ?? ""}
+                placeholder="Contoh: Sukajadi"
+                className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/40"
+              />
+            </div>
+            <div className="space-y-1">
+              <label htmlFor="storePostalCode" className="text-sm font-medium text-gray-700">
+                Kode pos
+              </label>
+              <input
+                id="storePostalCode"
+                name="postalCode"
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                defaultValue={account.storePostalCode ?? ""}
+                placeholder="Contoh: 40162"
+                className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/40"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="storeOriginCityId" className="text-sm font-medium text-gray-700">
+              Kode Kota RajaOngkir
+            </label>
+            <input
+              id="storeOriginCityId"
+              name="originCityId"
+              type="text"
+              defaultValue={account.storeOriginCityId ?? ""}
+              placeholder="Opsional, isi jika Anda tahu kode kota RajaOngkir"
+              className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/40"
+            />
+            <p className="text-xs text-gray-500">
+              Mengisi kode kota RajaOngkir membantu mempercepat pencocokan kota asal secara otomatis.
+            </p>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <button className="btn-primary" type="submit">
+              Simpan alamat
+            </button>
+            <span className="text-xs text-gray-500">Pastikan kota sesuai dengan data RajaOngkir agar ongkir otomatis berhasil.</span>
           </div>
         </form>
       </div>

--- a/components/ForgotPasswordForm.tsx
+++ b/components/ForgotPasswordForm.tsx
@@ -23,7 +23,7 @@ export default function ForgotPasswordForm() {
       const body = await response.json().catch(() => ({}));
 
       if (response.ok) {
-        setMessage(String(body.message ?? 'Kami telah mengirim OTP reset password apabila email terdaftar.'));
+        setMessage(String(body.message ?? 'Kami telah mengirim tautan reset password apabila email terdaftar.'));
         form.reset();
       } else {
         setError(String(body.message ?? body.error ?? 'Terjadi kesalahan. Coba lagi.'));
@@ -48,12 +48,12 @@ export default function ForgotPasswordForm() {
         className="w-full rounded bg-indigo-600 py-2 text-white hover:bg-indigo-700 disabled:opacity-50"
         disabled={isPending}
       >
-        {isPending ? 'Mengirim OTP...' : 'Kirim OTP Reset Password'}
+        {isPending ? 'Mengirim tautan...' : 'Kirim Link Reset Password'}
       </button>
       {message && <p className="rounded bg-green-50 px-3 py-2 text-sm text-green-700">{message}</p>}
       {error && <p className="rounded bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>}
       <p className="text-sm text-gray-600">
-        Kami akan mengirim kode OTP ke email Anda jika terdaftar. Gunakan kode tersebut untuk membuat password baru.
+        Kami akan mengirim tautan reset password ke email Anda jika terdaftar. Gunakan tautan tersebut untuk membuat password baru.
       </p>
     </form>
   );

--- a/components/ResetPasswordForm.tsx
+++ b/components/ResetPasswordForm.tsx
@@ -2,13 +2,28 @@
 
 import { FormEvent, useState, useTransition } from 'react';
 
-export default function ResetPasswordForm() {
-  const [error, setError] = useState<string | null>(null);
+type ResetPasswordFormProps = {
+  token: string | null;
+  isTokenValid: boolean;
+  invalidReason?: string;
+};
+
+export default function ResetPasswordForm({ token, isTokenValid, invalidReason }: ResetPasswordFormProps) {
+  const [error, setError] = useState<string | null>(
+    isTokenValid ? null : invalidReason ?? 'Token reset password tidak valid atau sudah tidak berlaku.',
+  );
   const [message, setMessage] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+
+    if (!token || !isTokenValid) {
+      setMessage(null);
+      setError('Token reset password tidak valid atau sudah tidak berlaku.');
+      return;
+    }
+
     const form = event.currentTarget;
     const formData = new FormData(form);
     const password = String(formData.get('password') ?? '');
@@ -33,36 +48,14 @@ export default function ResetPasswordForm() {
         setMessage(String(body.message ?? 'Password berhasil diperbarui.'));
         form.reset();
       } else {
-        setError(String(body.error ?? body.message ?? 'OTP atau email tidak valid.'));
+        setError(String(body.error ?? body.message ?? 'Token reset password tidak valid atau sudah tidak berlaku.'));
       }
     });
   };
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
-      <div>
-        <label className="block text-sm font-medium text-gray-700">Email</label>
-        <input
-          type="email"
-          name="email"
-          required
-          className="mt-1 w-full rounded border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-          placeholder="email yang terdaftar"
-        />
-      </div>
-      <div>
-        <label className="block text-sm font-medium text-gray-700">Kode OTP</label>
-        <input
-          type="text"
-          name="otp"
-          inputMode="numeric"
-          pattern="[0-9]{6}"
-          maxLength={6}
-          required
-          className="mt-1 w-full rounded border px-3 py-2 tracking-widest focus:outline-none focus:ring-2 focus:ring-indigo-500"
-          placeholder="6 digit kode"
-        />
-      </div>
+      <input type="hidden" name="token" value={token ?? ''} />
       <div>
         <label className="block text-sm font-medium text-gray-700">Password Baru</label>
         <input
@@ -88,14 +81,14 @@ export default function ResetPasswordForm() {
       <button
         type="submit"
         className="w-full rounded bg-indigo-600 py-2 text-white hover:bg-indigo-700 disabled:opacity-50"
-        disabled={isPending}
+        disabled={isPending || !token || !isTokenValid}
       >
         {isPending ? 'Memproses...' : 'Reset Password'}
       </button>
       {message && <p className="rounded bg-green-50 px-3 py-2 text-sm text-green-700">{message}</p>}
       {error && <p className="rounded bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>}
       <p className="text-sm text-gray-600">
-        Pastikan Anda menggunakan password yang kuat dan tidak membagikan kode OTP kepada siapapun.
+        Pastikan Anda menggunakan password yang kuat dan tidak membagikan tautan reset kepada siapapun.
       </p>
     </form>
   );

--- a/lib/password-reset.ts
+++ b/lib/password-reset.ts
@@ -1,0 +1,36 @@
+import { createHash, randomBytes } from "crypto";
+
+import { prisma } from "@/lib/prisma";
+
+export const PASSWORD_RESET_TOKEN_EXPIRATION_MINUTES = 30;
+
+export function generatePasswordResetToken() {
+  const token = randomBytes(32).toString("hex");
+  const tokenHash = hashPasswordResetToken(token);
+  const expiresAt = new Date(
+    Date.now() + PASSWORD_RESET_TOKEN_EXPIRATION_MINUTES * 60 * 1000,
+  );
+
+  return { token, tokenHash, expiresAt };
+}
+
+export function hashPasswordResetToken(token: string) {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+export async function findValidPasswordResetToken(token: string) {
+  if (!token) return null;
+
+  const tokenHash = hashPasswordResetToken(token);
+
+  const resetToken = await prisma.passwordResetToken.findUnique({
+    where: { tokenHash },
+    include: { user: { select: { id: true, email: true, name: true } } },
+  });
+
+  if (!resetToken) return null;
+  if (resetToken.usedAt) return null;
+  if (resetToken.expiresAt < new Date()) return null;
+
+  return resetToken;
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,12 @@ model User {
   storeFollowing Int      @default(0)
   storeRating    Float?
   storeRatingCount Int    @default(0)
+  storeAddressLine String?
+  storeProvince    String?
+  storeCity        String?
+  storeDistrict    String?
+  storePostalCode  String?
+  storeOriginCityId String?
 
   products     Product[]
   orderItems   OrderItem[] @relation("SellerItems")
@@ -251,7 +257,7 @@ model PasswordResetToken {
   id        String   @id @default(cuid())
   userId    String
   user      User     @relation(fields: [userId], references: [id])
-  otpHash   String
+  tokenHash String   @unique
   expiresAt DateTime
   usedAt    DateTime?
   createdAt DateTime @default(now())


### PR DESCRIPTION
## Summary
- replace the OTP-based password reset flow with single-use hashed tokens that are delivered through an emailed reset link
- add shared password reset helpers plus email templates for sending the link and success confirmation
- refresh the seller-facing forgot/reset password pages to drive the new link-based experience
- add seller store address management and use it as the default shipping origin when products lack warehouse data

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68e5387986808320a4c2278064dc024d