### PR TITLE
Add seller product edit workflow

### DIFF
--- a/app/api/seller/products/update/[id]/route.ts
+++ b/app/api/seller/products/update/[id]/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+
 import { prisma } from "@/lib/prisma";
 import { getIronSession } from "iron-session";
 import { sessionOptions, SessionUser } from "@/lib/session";
+import { buildVariantPayload, parseVariantInput, resolveCategorySlug } from "@/lib/product-form";
 
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
   const form = await req.formData();
@@ -30,6 +33,47 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
 
   if (toggle) {
     await prisma.product.update({ where: { id: prod.id }, data: { isActive: !prod.isActive } });
+    return NextResponse.redirect(new URL('/seller/products', req.url));
   }
-  return NextResponse.redirect(new URL('/seller/products', req.url));
+
+  const title = String(form.get('title') || '').trim();
+  const priceInput = String(form.get('price') || '').trim();
+  const parsedPrice = Number.parseInt(priceInput, 10);
+  const price = Number.isFinite(parsedPrice) ? parsedPrice : NaN;
+  const stockInput = String(form.get('stock') || '').trim();
+  const parsedStock = Number.parseInt(stockInput, 10);
+  const stock = Number.isFinite(parsedStock) ? Math.max(parsedStock, 0) : 0;
+  const originalPriceValue = String(form.get('originalPrice') || '').trim();
+  const parsedOriginalPrice = originalPriceValue ? Number.parseInt(originalPriceValue, 10) : NaN;
+  const originalPrice = Number.isFinite(parsedOriginalPrice) && parsedOriginalPrice > 0 ? parsedOriginalPrice : null;
+  const description = String(form.get('description') || '').trim();
+  const warehouseId = String(form.get('warehouseId') || '').trim();
+  const categoryRaw = String(form.get('category') || '').trim();
+  const variantsRaw = String(form.get('variants') || '').trim();
+
+  if (!title || Number.isNaN(price)) {
+    return NextResponse.redirect(
+      new URL(`/seller/products/${prod.id}/edit?error=${encodeURIComponent('Form tidak valid')}`, req.url)
+    );
+  }
+
+  const finalOriginalPrice = originalPrice && originalPrice > price ? originalPrice : null;
+  const variantGroups = parseVariantInput(variantsRaw);
+  const variantPayload = buildVariantPayload(variantGroups);
+
+  await prisma.product.update({
+    where: { id: prod.id },
+    data: {
+      title,
+      price,
+      stock,
+      description,
+      warehouseId: warehouseId || null,
+      category: resolveCategorySlug(categoryRaw),
+      originalPrice: finalOriginalPrice,
+      variantOptions: variantPayload ?? Prisma.JsonNull,
+    },
+  });
+
+  return NextResponse.redirect(new URL('/seller/products?updated=1', req.url));
 }

--- a/app/seller/products/[id]/edit/page.tsx
+++ b/app/seller/products/[id]/edit/page.tsx
@@ -1,0 +1,225 @@
+import Link from "next/link";
+
+import { prisma } from "@/lib/prisma";
+import { getSession } from "@/lib/session";
+import { productCategories } from "@/lib/categories";
+import { stringifyVariantGroups } from "@/lib/product-form";
+
+export const dynamic = 'force-dynamic';
+
+export default async function SellerEditProductPage({
+  params,
+  searchParams,
+}: {
+  params: { id: string };
+  searchParams?: Record<string, string | string[] | undefined>;
+}) {
+  const session = await getSession();
+  const user = session.user;
+  if (!user) {
+    return <div>Harap login.</div>;
+  }
+
+  const account = await prisma.user.findUnique({
+    where: { id: user.id },
+    select: { isBanned: true, sellerOnboardingStatus: true },
+  });
+
+  if (!account || account.isBanned) {
+    return (
+      <div>
+        <h1 className="text-2xl font-semibold mb-4">Edit Produk</h1>
+        <div className="rounded border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          Akun Anda sedang diblokir sehingga tidak dapat mengelola produk. Hubungi
+          {" "}
+          <a className="underline" href="mailto:support@akay.id">
+            support@akay.id
+          </a>
+          {" "}
+          untuk bantuan lebih lanjut.
+        </div>
+      </div>
+    );
+  }
+
+  if (account.sellerOnboardingStatus !== "ACTIVE") {
+    return (
+      <div>
+        <h1 className="text-2xl font-semibold mb-4">Edit Produk</h1>
+        <div className="rounded border border-amber-200 bg-amber-50 p-4 text-sm text-amber-700">
+          Fitur manajemen produk tersedia setelah toko Anda diaktifkan. Selesaikan langkah onboarding pada halaman
+          <a className="ml-1 font-semibold underline" href="/seller/onboarding">
+            onboarding seller
+          </a>
+          .
+        </div>
+      </div>
+    );
+  }
+
+  const [product, warehouses] = await Promise.all([
+    prisma.product.findFirst({
+      where: { id: params.id, sellerId: user.id },
+      select: {
+        id: true,
+        title: true,
+        description: true,
+        price: true,
+        originalPrice: true,
+        stock: true,
+        category: true,
+        variantOptions: true,
+        warehouseId: true,
+        isActive: true,
+      },
+    }),
+    prisma.warehouse.findMany({ where: { ownerId: user.id }, orderBy: { createdAt: "desc" } }),
+  ]);
+
+  if (!product) {
+    return (
+      <div>
+        <h1 className="text-2xl font-semibold mb-4">Edit Produk</h1>
+        <div className="rounded border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          Produk tidak ditemukan atau Anda tidak memiliki akses ke produk ini.
+        </div>
+        <Link href="/seller/products" className="btn-primary mt-4 inline-block">
+          Kembali ke daftar produk
+        </Link>
+      </div>
+    );
+  }
+
+  const variantText = stringifyVariantGroups(product.variantOptions);
+  const errorMessageRaw = searchParams?.error;
+  const errorMessage = Array.isArray(errorMessageRaw) ? errorMessageRaw[0] : errorMessageRaw;
+
+  return (
+    <div>
+      <div className="mb-4 flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Edit Produk</h1>
+        <Link href="/seller/products" className="text-sm text-blue-600 underline">
+          &larr; Kembali ke Produk Saya
+        </Link>
+      </div>
+      <div className="mb-4">
+        <span className={`badge ${product.isActive ? "badge-paid" : "badge-pending"}`}>
+          Status: {product.isActive ? "Aktif" : "Nonaktif"}
+        </span>
+      </div>
+      {errorMessage ? (
+        <div className="mb-4 rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          {errorMessage}
+        </div>
+      ) : null}
+      <div className="rounded border bg-white p-4">
+        <form method="POST" action={`/api/seller/products/update/${product.id}`} className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          <label className="md:col-span-2 text-sm font-medium text-gray-700" htmlFor="title">
+            Judul Produk
+          </label>
+          <input
+            id="title"
+            name="title"
+            required
+            defaultValue={product.title}
+            className="border rounded px-3 py-2 md:col-span-2"
+          />
+          <label className="text-sm font-medium text-gray-700" htmlFor="category">
+            Kategori
+          </label>
+          <select
+            id="category"
+            name="category"
+            required
+            defaultValue={product.category}
+            className="border rounded px-3 py-2"
+          >
+            {productCategories.map((category) => (
+              <option key={category.slug} value={category.slug}>
+                {category.emoji} {category.name}
+              </option>
+            ))}
+          </select>
+          <label className="text-sm font-medium text-gray-700" htmlFor="warehouseId">
+            Gudang
+          </label>
+          <select
+            id="warehouseId"
+            name="warehouseId"
+            defaultValue={product.warehouseId ?? ""}
+            className="border rounded px-3 py-2"
+          >
+            <option value="">Tidak ada gudang</option>
+            {warehouses.map((warehouse) => (
+              <option key={warehouse.id} value={warehouse.id}>
+                {warehouse.name}
+                {warehouse.city ? ` - ${warehouse.city}` : ""}
+              </option>
+            ))}
+          </select>
+          <label className="text-sm font-medium text-gray-700" htmlFor="price">
+            Harga (integer)
+          </label>
+          <input
+            id="price"
+            name="price"
+            required
+            type="number"
+            defaultValue={product.price}
+            className="border rounded px-3 py-2"
+          />
+          <label className="text-sm font-medium text-gray-700" htmlFor="originalPrice">
+            Harga Sebelum Diskon (opsional)
+          </label>
+          <input
+            id="originalPrice"
+            name="originalPrice"
+            type="number"
+            defaultValue={product.originalPrice ?? ""}
+            className="border rounded px-3 py-2"
+          />
+          <label className="text-sm font-medium text-gray-700" htmlFor="stock">
+            Stok
+          </label>
+          <input
+            id="stock"
+            name="stock"
+            type="number"
+            defaultValue={product.stock}
+            className="border rounded px-3 py-2"
+          />
+          <label className="text-sm font-medium text-gray-700 md:col-span-2" htmlFor="description">
+            Deskripsi
+          </label>
+          <textarea
+            id="description"
+            name="description"
+            defaultValue={product.description ?? ""}
+            className="border rounded px-3 py-2 md:col-span-2 min-h-[120px]"
+          ></textarea>
+          <label className="text-sm font-medium text-gray-700 md:col-span-2" htmlFor="variants">
+            Varian
+          </label>
+          <textarea
+            id="variants"
+            name="variants"
+            defaultValue={variantText}
+            placeholder={"Varian (contoh: Warna: Hitam, Putih)\nUkuran: 64GB, 128GB"}
+            className="border rounded px-3 py-2 md:col-span-2 min-h-[120px]"
+          ></textarea>
+          <p className="text-xs text-gray-500 md:col-span-2">
+            Tambahkan setiap kelompok varian di baris baru dengan format <span className="font-medium">Nama: opsi1, opsi2</span>.
+          </p>
+          <div className="md:col-span-2 flex justify-end gap-2">
+            <Link href="/seller/products" className="btn-outline">
+              Batal
+            </Link>
+            <button className="btn-primary" type="submit">
+              Simpan Perubahan
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/seller/products/page.tsx
+++ b/app/seller/products/page.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 import { prisma } from "@/lib/prisma";
 import { getSession } from "@/lib/session";
 import { productCategories, getCategoryInfo } from "@/lib/categories";
@@ -5,7 +7,11 @@ import { formatFlashSaleWindow, isFlashSaleActive } from "@/lib/flash-sale";
 
 export const dynamic = 'force-dynamic';
 
-export default async function SellerProducts() {
+export default async function SellerProducts({
+  searchParams,
+}: {
+  searchParams?: Record<string, string | string[] | undefined>;
+}) {
   const session = await getSession();
   const user = session.user;
   if (!user) return <div>Harap login.</div>;
@@ -66,9 +72,16 @@ export default async function SellerProducts() {
 
   const categoryLabel = (slug: string) => getCategoryInfo(slug)?.name ?? slug.replace(/-/g, ' ');
 
+  const updatedFlag = typeof searchParams?.updated === 'string' || Array.isArray(searchParams?.updated);
+
   return (
     <div>
       <h1 className="text-2xl font-semibold mb-4">Produk Saya</h1>
+      {updatedFlag ? (
+        <div className="mb-4 rounded border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-700">
+          Perubahan produk berhasil disimpan.
+        </div>
+      ) : null}
       <div className="bg-white border rounded p-4 mb-6">
         <h2 className="font-semibold mb-2">Tambah Produk</h2>
         <form
@@ -176,6 +189,9 @@ export default async function SellerProducts() {
                   })()}
                 </td>
                 <td className="space-x-2">
+                  <Link href={`/seller/products/${p.id}/edit`} className="btn-outline inline-block">
+                    Edit
+                  </Link>
                   <form method="POST" action={`/api/seller/products/update/${p.id}`} className="inline">
                     <input type="hidden" name="toggle" value="1"/>
                     <button className="btn-outline">{p.isActive ? 'Nonaktifkan':'Aktifkan'}</button>

--- a/lib/product-form.ts
+++ b/lib/product-form.ts
@@ -1,0 +1,74 @@
+import { productCategories } from "@/lib/categories";
+import { VariantGroup } from "@/types/product";
+
+type VariantJson = {
+  name?: unknown;
+  options?: unknown;
+};
+
+export function parseVariantInput(raw: string): VariantGroup[] {
+  if (!raw.trim()) return [];
+
+  return raw
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [namePart, optionsPart = ""] = line.split(":");
+      const name = namePart.trim();
+      const options = optionsPart
+        .split(",")
+        .map((option) => option.trim())
+        .filter(Boolean);
+
+      if (!name) {
+        return null;
+      }
+
+      return {
+        name,
+        options: options.length > 0 ? options : ["Default"],
+      } satisfies VariantGroup;
+    })
+    .filter((group): group is VariantGroup => Boolean(group));
+}
+
+export function buildVariantPayload(variantGroups: VariantGroup[]) {
+  if (variantGroups.length === 0) {
+    return null;
+  }
+
+  return variantGroups.map((group) => ({
+    name: group.name,
+    options: [...group.options],
+  }));
+}
+
+export function stringifyVariantGroups(variantOptions: unknown): string {
+  if (!Array.isArray(variantOptions)) return "";
+
+  const lines = variantOptions
+    .map((item) => {
+      const group = item as VariantJson;
+      const name = typeof group.name === "string" ? group.name.trim() : "";
+      if (!name) return null;
+
+      const options = Array.isArray(group.options)
+        ? group.options.filter((option): option is string => typeof option === "string" && option.trim().length > 0)
+        : [];
+
+      const optionsPart = options.length > 0 ? options.join(", ") : "";
+      return optionsPart ? `${name}: ${optionsPart}` : `${name}:`;
+    })
+    .filter((line): line is string => Boolean(line));
+
+  return lines.join("\n");
+}
+
+export function resolveCategorySlug(rawCategory: string) {
+  const trimmed = rawCategory.trim();
+  const fallback = productCategories[0]?.slug || "umum";
+
+  if (!trimmed) return fallback;
+  return productCategories.some((category) => category.slug === trimmed) ? trimmed : fallback;
+}

--- a/prisma/migrations/20251004000017_add_user_store_address_fields/migration.sql
+++ b/prisma/migrations/20251004000017_add_user_store_address_fields/migration.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "User"
+  ADD COLUMN "storeAddressLine" TEXT,
+  ADD COLUMN "storeProvince" TEXT,
+  ADD COLUMN "storeCity" TEXT,
+  ADD COLUMN "storeDistrict" TEXT,
+  ADD COLUMN "storePostalCode" TEXT,
+  ADD COLUMN "storeOriginCityId" TEXT;


### PR DESCRIPTION
## Summary
- extract shared helpers for parsing and formatting product variant and category form inputs
- add a seller product edit page and enhance the update API to persist product detail changes
- surface an edit link and success notice in the seller product list after saving updates

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e54bce39e88320a7a66a49133da93b