### PR TITLE
Refine mobile layouts for marketplace surfaces

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { AddressRegionFields } from "@/components/AddressRegionFields";
@@ -57,6 +58,21 @@ export default async function AccountPage({ searchParams }: AccountPageProps) {
     redirect("/seller/login");
   }
 
+  const [pendingOrders, cancelledOrders, packedItems, shippedItems, deliveredItems] = await Promise.all([
+    prisma.order.count({ where: { buyerId: viewer.id, status: "PENDING" } }),
+    prisma.order.count({ where: { buyerId: viewer.id, status: "CANCELLED" } }),
+    prisma.orderItem.count({ where: { order: { buyerId: viewer.id }, status: "PACKED" } }),
+    prisma.orderItem.count({ where: { order: { buyerId: viewer.id }, status: "SHIPPED" } }),
+    prisma.orderItem.count({ where: { order: { buyerId: viewer.id }, status: "DELIVERED" } }),
+  ]);
+
+  const orderSummary = [
+    { label: "Belum Bayar", value: pendingOrders, icon: "💳", href: "/orders?status=PENDING" },
+    { label: "Dikemas", value: packedItems, icon: "📦", href: "/orders?status=PACKED" },
+    { label: "Dikirim", value: shippedItems, icon: "🚚", href: "/orders?status=SHIPPED" },
+    { label: "Selesai", value: deliveredItems, icon: "✅", href: "/orders?status=DELIVERED" },
+  ];
+
   const profileError = typeof searchParams?.profileError === "string" ? searchParams.profileError : null;
   const profileUpdated = searchParams?.profileUpdated === "1";
   const addressError = typeof searchParams?.addressError === "string" ? searchParams.addressError : null;
@@ -70,7 +86,82 @@ export default async function AccountPage({ searchParams }: AccountPageProps) {
 
   return (
     <div className="mx-auto max-w-5xl space-y-8 px-4 py-8">
-      <header className="space-y-1">
+      <div className="space-y-4 md:hidden">
+        <div className="rounded-3xl bg-gradient-to-br from-[#f53d2d] via-[#ff6f3c] to-[#ff9364] px-6 py-6 text-white shadow-lg">
+          <div className="flex items-center gap-4">
+            <div className="flex h-14 w-14 items-center justify-center rounded-full bg-white/20 text-2xl font-semibold">
+              {account.name.charAt(0).toUpperCase()}
+            </div>
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-wider text-white/70">Akun Saya</p>
+              <p className="text-lg font-semibold">{account.name}</p>
+              <p className="text-xs text-white/80">{account.email}</p>
+            </div>
+          </div>
+          <div className="mt-5 flex items-center justify-between text-xs font-medium text-white/90">
+            <div>
+              <p className="text-white/70">Alamat Utama</p>
+              <p className="max-w-[220px] text-white">
+                {account.addresses[0]
+                  ? `${account.addresses[0].addressLine}, ${account.addresses[0].city}`
+                  : "Belum ada alamat tersimpan"}
+              </p>
+            </div>
+            <Link href="/orders" className="rounded-full bg-white/20 px-4 py-2 text-xs font-semibold text-white">
+              Pesanan Saya
+            </Link>
+          </div>
+        </div>
+        <div className="rounded-3xl bg-white p-5 shadow-md">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900">Pesanan Saya</h2>
+              <p className="text-xs text-gray-500">Lacak status terbaru transaksi Anda.</p>
+            </div>
+            <Link href="/orders" className="text-xs font-semibold text-[#f53d2d]">
+              Lihat riwayat
+            </Link>
+          </div>
+          <div className="mt-4 grid grid-cols-4 gap-3 text-center text-[11px] font-medium text-gray-700">
+            {orderSummary.map((item) => (
+              <Link
+                key={item.label}
+                href={item.href}
+                className="flex flex-col items-center gap-1 rounded-2xl border border-gray-100 bg-gray-50 px-2 py-3 shadow-sm"
+              >
+                <span className="text-xl">{item.icon}</span>
+                <span className="text-xs text-gray-900">{item.label}</span>
+                <span className="text-[11px] font-semibold text-[#f53d2d]">{item.value}</span>
+              </Link>
+            ))}
+            <Link
+              href="/orders?status=CANCELLED"
+              className="flex flex-col items-center gap-1 rounded-2xl border border-gray-100 bg-gray-50 px-2 py-3 shadow-sm"
+            >
+              <span className="text-xl">🚫</span>
+              <span className="text-xs text-gray-900">Dibatalkan</span>
+              <span className="text-[11px] font-semibold text-[#f53d2d]">{cancelledOrders}</span>
+            </Link>
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-3 text-xs font-semibold text-gray-700">
+          <Link href="/voucher" className="flex items-center gap-3 rounded-2xl bg-white px-4 py-3 shadow-sm">
+            <span className="text-lg">🎁</span>
+            <div>
+              <p className="text-sm text-gray-900">Voucher Saya</p>
+              <p className="text-xs font-normal text-gray-500">Cek promo dan cashback terbaru</p>
+            </div>
+          </Link>
+          <Link href="/support" className="flex items-center gap-3 rounded-2xl bg-white px-4 py-3 shadow-sm">
+            <span className="text-lg">🛟</span>
+            <div>
+              <p className="text-sm text-gray-900">Bantuan</p>
+              <p className="text-xs font-normal text-gray-500">Pusat bantuan dan layanan pelanggan</p>
+            </div>
+          </Link>
+        </div>
+      </div>
+      <header className="hidden space-y-1 md:block">
         <h1 className="text-3xl font-semibold text-gray-900">Akun Saya</h1>
         <p className="text-sm text-gray-600">Kelola informasi profil dan alamat pengiriman Anda.</p>
       </header>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import { SiteFooter } from "@/components/SiteFooter";
 import { SiteHeader } from "@/components/SiteHeader";
+import { MobileTabBar } from "@/components/MobileTabBar";
 import { getSession, SessionUser } from "@/lib/session";
 
 export const metadata = {
@@ -20,8 +21,9 @@ export default async function RootLayout({ children }: { children: React.ReactNo
     <html lang="id">
       <body className="bg-gray-50 text-gray-900">
         <SiteHeader user={user} />
-        <main className="mx-auto max-w-6xl px-4 py-6">{children}</main>
+        <main className="mx-auto max-w-6xl px-4 pb-28 pt-6 md:pb-12">{children}</main>
         <SiteFooter />
+        <MobileTabBar />
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -134,7 +134,65 @@ export default async function HomePage() {
       ) : null}
       <PromoSlider slides={slides.length > 0 ? slides : fallbackSlides} />
 
-      <section>
+      <div className="space-y-4 md:hidden">
+        <div className="rounded-3xl bg-gradient-to-br from-white/95 via-white/90 to-white/70 px-5 py-4 text-gray-900 shadow-xl shadow-[#f53d2d]/10 ring-1 ring-white/70">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-xs uppercase tracking-wide text-gray-500">Voucher Pilihan</p>
+              <p className="text-lg font-semibold text-[#f53d2d]">
+                {highlightedVoucher ? highlightedVoucher.code : "Diskon Spesial"}
+              </p>
+              <p className="text-xs text-gray-500">
+                {highlightedVoucher
+                  ? `Potongan hingga Rp ${formatIDR(highlightedVoucher.value)}`
+                  : "Nikmati penawaran terbaik setiap hari"}
+              </p>
+            </div>
+            <Link
+              href={highlightedVoucher ? `/voucher/${highlightedVoucher.code}` : "/promo"}
+              className="rounded-full bg-[#f53d2d] px-4 py-2 text-xs font-semibold text-white shadow"
+            >
+              Klaim
+            </Link>
+          </div>
+        </div>
+        <div className="grid grid-cols-4 gap-3 text-center text-xs font-medium text-gray-700">
+          <Link href="/promo" className="flex flex-col items-center gap-2 rounded-2xl bg-white p-3 shadow-sm">
+            <span className="text-lg">💳</span>
+            <span>Pulsa</span>
+          </Link>
+          <Link href="/promo" className="flex flex-col items-center gap-2 rounded-2xl bg-white p-3 shadow-sm">
+            <span className="text-lg">🧾</span>
+            <span>Tagihan</span>
+          </Link>
+          <Link href="/promo" className="flex flex-col items-center gap-2 rounded-2xl bg-white p-3 shadow-sm">
+            <span className="text-lg">🎟️</span>
+            <span>Voucher</span>
+          </Link>
+          <Link href="#flash-sale" className="flex flex-col items-center gap-2 rounded-2xl bg-white p-3 shadow-sm">
+            <span className="text-lg">🔥</span>
+            <span>Flash</span>
+          </Link>
+          <Link href="/promo" className="flex flex-col items-center gap-2 rounded-2xl bg-white p-3 shadow-sm">
+            <span className="text-lg">🍱</span>
+            <span>Food</span>
+          </Link>
+          <Link href="/promo" className="flex flex-col items-center gap-2 rounded-2xl bg-white p-3 shadow-sm">
+            <span className="text-lg">📺</span>
+            <span>Video</span>
+          </Link>
+          <Link href="/promo" className="flex flex-col items-center gap-2 rounded-2xl bg-white p-3 shadow-sm">
+            <span className="text-lg">📡</span>
+            <span>Live</span>
+          </Link>
+          <Link href="/support" className="flex flex-col items-center gap-2 rounded-2xl bg-white p-3 shadow-sm">
+            <span className="text-lg">🆘</span>
+            <span>Bantuan</span>
+          </Link>
+      </div>
+      </div>
+
+      <section id="flash-sale">
         <FlashSaleRail items={flashSaleProducts} />
       </section>
 

--- a/app/seller/dashboard/page.tsx
+++ b/app/seller/dashboard/page.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 import { Prisma } from "@prisma/client";
 
 import { prisma } from "@/lib/prisma";
@@ -135,84 +137,229 @@ export default async function Dashboard() {
   const storeAddressLine = account.storeAddressLine?.trim() ?? "";
   const hasStoreOrigin = Boolean(storeCity);
 
-  const [pcount, orders, revenue] = await Promise.all([
+  const [
+    productCount,
+    distinctOrders,
+    revenueAggregate,
+    pendingItemCount,
+    packedItemCount,
+    shippedItemCount,
+    deliveredItemCount,
+    returnRequestCount,
+  ] = await Promise.all([
     prisma.product.count({ where: { sellerId: user.id } }),
     prisma.orderItem.findMany({ where: { sellerId: user.id }, select: { orderId: true }, distinct: ["orderId"] }),
-    prisma.orderItem.aggregate({ where: { sellerId: user.id, order: { status: 'PAID' } }, _sum: { price: true } })
+    prisma.orderItem.aggregate({ where: { sellerId: user.id, order: { status: 'PAID' } }, _sum: { price: true } }),
+    prisma.orderItem.count({ where: { sellerId: user.id, status: "PENDING" } }),
+    prisma.orderItem.count({ where: { sellerId: user.id, status: "PACKED" } }),
+    prisma.orderItem.count({ where: { sellerId: user.id, status: "SHIPPED" } }),
+    prisma.orderItem.count({ where: { sellerId: user.id, status: "DELIVERED" } }),
+    prisma.returnRequest.count({ where: { orderItem: { sellerId: user.id }, status: "REQUESTED" } }),
   ]);
 
+  const ordersCount = distinctOrders.length;
+  const revenueTotal = revenueAggregate._sum.price ?? 0;
+
+  const sellerOrderSummary = [
+    { label: "Perlu Diproses", value: pendingItemCount, icon: "🧾", href: "/seller/orders?status=PENDING" },
+    { label: "Dikemas", value: packedItemCount, icon: "📦", href: "/seller/orders?status=PACKED" },
+    { label: "Dikirim", value: shippedItemCount, icon: "🚚", href: "/seller/orders?status=SHIPPED" },
+    { label: "Selesai", value: deliveredItemCount, icon: "✅", href: "/seller/orders?status=DELIVERED" },
+    { label: "Retur", value: returnRequestCount, icon: "↩️", href: "/seller/returns" },
+  ];
+
+  const sellerTools = [
+    { label: "Produk", icon: "🛒", href: "/seller/products" },
+    { label: "Pesanan", icon: "📬", href: "/seller/orders" },
+    { label: "Flash Sale", icon: "⚡", href: "/seller/flash-sales" },
+    { label: "Gudang", icon: "🏬", href: "/seller/warehouses" },
+    { label: "Retur", icon: "↩️", href: "/seller/returns" },
+    { label: "Pengaturan", icon: "⚙️", href: "/seller/settings" },
+  ];
+
   return (
-    <div>
-      <h1 className="text-2xl font-semibold mb-4">Dashboard Seller</h1>
-      <div className="bg-white border rounded p-4 mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-        <div className="space-y-1">
-          <h2 className="font-semibold text-lg">Profil Toko</h2>
-          <div className="text-sm text-gray-600">
-            <div className="font-medium text-gray-900">{storeName}</div>
-            <div className="text-xs text-gray-500">Alamat etalase: https://akay.id/s/{storeSlug}</div>
+    <div className="space-y-6">
+      <div className="space-y-4 md:hidden">
+        <div className="rounded-3xl bg-gradient-to-br from-[#f53d2d] via-[#ff6f3c] to-[#ff8f59] px-6 py-6 text-white shadow-xl">
+          <div className="flex items-start justify-between gap-3">
+            <div className="space-y-1">
+              <p className="text-xs uppercase tracking-wider text-white/70">Dashboard Seller</p>
+              <p className="text-2xl font-semibold">{storeName}</p>
+              <p className="text-xs text-white/80">https://akay.id/s/{storeSlug}</p>
+              {hasStoreOrigin ? (
+                <p className="text-xs text-white/80">
+                  Gudang: {storeAddressLine ? `${storeAddressLine}, ` : ""}
+                  {storeCity}
+                  {storeProvince ? `, ${storeProvince}` : ""}
+                </p>
+              ) : (
+                <p className="text-xs text-white/80">
+                  Lengkapi alamat gudang untuk aktifkan ongkir otomatis.
+                </p>
+              )}
+            </div>
+            <form method="POST" action="/api/seller/store/toggle" className="flex-shrink-0">
+              <input type="hidden" name="status" value={storeIsOnline ? "offline" : "online"} />
+              <button className="rounded-full bg-white px-4 py-2 text-xs font-semibold text-[#f53d2d] shadow">
+                {storeIsOnline ? "Tutup Toko" : "Buka Toko"}
+              </button>
+            </form>
+          </div>
+          <div className="mt-4 flex items-center justify-between text-xs text-white/80">
+            <Link href={`/s/${storeSlug}`} className="inline-flex items-center gap-1 rounded-full bg-white/20 px-4 py-2 text-xs font-semibold text-white">
+              Lihat Toko
+            </Link>
+            <Link href="/seller/settings" className="text-xs font-semibold underline">
+              Pengaturan
+            </Link>
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <div className="rounded-2xl bg-white p-4 text-gray-900 shadow-sm">
+            <p className="text-xs text-gray-500">Produk Aktif</p>
+            <p className="text-xl font-semibold text-[#f53d2d]">{productCount}</p>
+          </div>
+          <div className="rounded-2xl bg-white p-4 text-gray-900 shadow-sm">
+            <p className="text-xs text-gray-500">Pesanan Unik</p>
+            <p className="text-xl font-semibold text-[#f53d2d]">{ordersCount}</p>
+          </div>
+          <div className="rounded-2xl bg-white p-4 text-gray-900 shadow-sm">
+            <p className="text-xs text-gray-500">Omzet (Paid)</p>
+            <p className="text-xl font-semibold text-[#f53d2d]">Rp {new Intl.NumberFormat("id-ID").format(revenueTotal)}</p>
+          </div>
+          <div className="rounded-2xl bg-white p-4 text-gray-900 shadow-sm">
+            <p className="text-xs text-gray-500">Permintaan Retur</p>
+            <p className="text-xl font-semibold text-[#f53d2d]">{returnRequestCount}</p>
+          </div>
+        </div>
+        <div className="rounded-3xl bg-white p-5 shadow-sm">
+          <div className="flex items-center justify-between">
+            <h2 className="text-base font-semibold text-gray-900">Status Pesanan</h2>
+            <Link href="/seller/orders" className="text-xs font-semibold text-[#f53d2d]">
+              Lihat Semua
+            </Link>
+          </div>
+          <div className="mt-4 grid grid-cols-3 gap-3 text-center text-[11px] font-medium text-gray-700">
+            {sellerOrderSummary.map((item) => (
+              <Link
+                key={item.label}
+                href={item.href}
+                className="flex flex-col items-center gap-1 rounded-2xl border border-gray-100 bg-gray-50 px-2 py-3 shadow-sm"
+              >
+                <span className="text-xl">{item.icon}</span>
+                <span className="text-xs text-gray-900">{item.label}</span>
+                <span className="text-[11px] font-semibold text-[#f53d2d]">{item.value}</span>
+              </Link>
+            ))}
+          </div>
+        </div>
+        <div className="rounded-3xl bg-white p-5 shadow-sm">
+          <div className="flex items-center justify-between">
+            <h2 className="text-base font-semibold text-gray-900">Alat Toko</h2>
+            <Link href="/seller/settings" className="text-xs font-semibold text-[#f53d2d]">
+              Selengkapnya
+            </Link>
+          </div>
+          <div className="mt-4 grid grid-cols-3 gap-3 text-center text-xs font-semibold text-gray-700">
+            {sellerTools.map((tool) => (
+              <Link
+                key={tool.label}
+                href={tool.href}
+                className="flex flex-col items-center gap-1 rounded-2xl border border-gray-100 bg-gray-50 px-3 py-4 shadow-sm"
+              >
+                <span className="text-xl">{tool.icon}</span>
+                <span>{tool.label}</span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </div>
+      <div className="hidden space-y-6 md:block">
+        <h1 className="text-2xl font-semibold">Dashboard Seller</h1>
+        <div className="flex flex-col gap-4 rounded border bg-white p-4 md:flex-row md:items-center md:justify-between">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold">Profil Toko</h2>
+            <div className="text-sm text-gray-600">
+              <div className="font-medium text-gray-900">{storeName}</div>
+              <div className="text-xs text-gray-500">Alamat etalase: https://akay.id/s/{storeSlug}</div>
+              {hasStoreOrigin ? (
+                <div className="mt-1 text-xs text-gray-500">
+                  Gudang: {storeAddressLine ? `${storeAddressLine}, ` : ""}
+                  {storeCity}
+                  {storeProvince ? `, ${storeProvince}` : ""}
+                </div>
+              ) : (
+                <div className="mt-1 text-xs text-amber-600">
+                  Tambahkan alamat gudang di pengaturan toko agar ongkos kirim dapat dihitung otomatis.
+                </div>
+              )}
+            </div>
             {hasStoreOrigin ? (
-              <div className="mt-1 text-xs text-gray-500">
-                Gudang: {storeAddressLine ? `${storeAddressLine}, ` : ""}
-                {storeCity}
-                {storeProvince ? `, ${storeProvince}` : ""}
+              <div className="text-sm text-gray-600">
+                <div className="font-medium text-gray-900">Alamat pengiriman toko</div>
+                <p>
+                  {[storeAddressLine, storeCity, storeProvince]
+                    .filter((part) => part && part.length > 0)
+                    .join(", ")}
+                </p>
               </div>
             ) : (
-              <div className="mt-1 text-xs text-amber-600">
-                Tambahkan alamat gudang di pengaturan toko agar ongkos kirim dapat dihitung otomatis.
+              <div className="rounded border border-amber-200 bg-amber-50 p-3 text-xs text-amber-700">
+                Lengkapi alamat toko Anda agar ongkir otomatis dapat menggunakan kota asal toko saat produk belum diatur ke
+                gudang tertentu.
               </div>
             )}
+            <a className="text-sm font-semibold text-[#f53d2d] hover:text-[#d63b22]" href="/seller/settings">
+              Atur nama &amp; alamat toko →
+            </a>
           </div>
-          {hasStoreOrigin ? (
-            <div className="text-sm text-gray-600">
-              <div className="font-medium text-gray-900">Alamat pengiriman toko</div>
-              <p>
-                {[storeAddressLine, storeCity, storeProvince]
-                  .filter((part) => part && part.length > 0)
-                  .join(", ")}
-              </p>
-            </div>
-          ) : (
-            <div className="rounded border border-amber-200 bg-amber-50 p-3 text-xs text-amber-700">
-              Lengkapi alamat toko Anda agar ongkir otomatis dapat menggunakan kota asal toko saat produk belum diatur ke
-              gudang tertentu.
-            </div>
-          )}
-          <a className="text-sm font-semibold text-[#f53d2d] hover:text-[#d63b22]" href="/seller/settings">
-            Atur nama &amp; alamat toko →
-          </a>
+          <div>
+            <h2 className="text-lg font-semibold">Status Toko</h2>
+            <p className="text-sm text-gray-600">
+              {storeIsOnline
+                ? "Toko Anda sedang buka dan pelanggan dapat melakukan pembelian."
+                : "Toko Anda sedang ditutup. Buka kembali agar pelanggan dapat berbelanja."}
+            </p>
+          </div>
+          <form method="POST" action="/api/seller/store/toggle" className="flex-shrink-0">
+            <input type="hidden" name="status" value={storeIsOnline ? "offline" : "online"} />
+            <button className={storeIsOnline ? "btn-outline" : "btn-primary"}>
+              {storeIsOnline ? "Tutup Toko" : "Buka Toko"}
+            </button>
+          </form>
         </div>
-        <div>
-          <h2 className="font-semibold text-lg">Status Toko</h2>
-          <p className="text-sm text-gray-600">
-            {storeIsOnline
-              ? "Toko Anda sedang buka dan pelanggan dapat melakukan pembelian."
-              : "Toko Anda sedang ditutup. Buka kembali agar pelanggan dapat berbelanja."}
-          </p>
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          <div className="rounded border bg-white p-4">
+            <div className="text-sm text-gray-500">Produk</div>
+            <div className="text-2xl font-bold">{productCount}</div>
+          </div>
+          <div className="rounded border bg-white p-4">
+            <div className="text-sm text-gray-500">Pesanan</div>
+            <div className="text-2xl font-bold">{ordersCount}</div>
+          </div>
+          <div className="rounded border bg-white p-4">
+            <div className="text-sm text-gray-500">Omzet (Paid)</div>
+            <div className="text-2xl font-bold">Rp {new Intl.NumberFormat("id-ID").format(revenueTotal)}</div>
+          </div>
         </div>
-        <form method="POST" action="/api/seller/store/toggle" className="flex-shrink-0">
-          <input
-            type="hidden"
-            name="status"
-            value={storeIsOnline ? "offline" : "online"}
-          />
-          <button className={storeIsOnline ? "btn-outline" : "btn-primary"}>
-            {storeIsOnline ? "Tutup Toko" : "Buka Toko"}
-          </button>
-        </form>
-      </div>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div className="bg-white border rounded p-4"><div className="text-sm text-gray-500">Produk</div><div className="text-2xl font-bold">{pcount}</div></div>
-        <div className="bg-white border rounded p-4"><div className="text-sm text-gray-500">Pesanan</div><div className="text-2xl font-bold">{orders.length}</div></div>
-        <div className="bg-white border rounded p-4"><div className="text-sm text-gray-500">Omzet (Paid)</div><div className="text-2xl font-bold">Rp {new Intl.NumberFormat('id-ID').format(revenue._sum.price || 0)}</div></div>
-      </div>
-      <div className="mt-6 flex flex-wrap gap-2">
-        <a className="btn-primary" href="/seller/products">Kelola Produk</a>
-        <a className="btn-outline" href="/seller/orders">Pesanan Saya</a>
-        <a className="btn-outline" href="/seller/warehouses">Gudang</a>
-        <a className="btn-outline" href="/seller/returns">Retur</a>
-        <a className="btn-outline" href="/seller/flash-sales">Flash Sale</a>
-        <a className="btn-outline" href={`/s/${storeSlug}`} target="_blank">Lihat Toko</a>
-        <a className="btn-outline" href="/seller/settings">Pengaturan Toko</a>
+        <div className="grid grid-cols-5 gap-3 rounded border bg-white p-4">
+          {sellerOrderSummary.map((item) => (
+            <a key={item.label} href={item.href} className="flex flex-col items-center gap-2 text-sm text-gray-600 hover:text-[#f53d2d]">
+              <span className="text-xl">{item.icon}</span>
+              <span className="font-semibold text-gray-900">{item.value}</span>
+              <span className="text-xs">{item.label}</span>
+            </a>
+          ))}
+        </div>
+        <div className="mt-2 flex flex-wrap gap-2">
+          <a className="btn-primary" href="/seller/products">Kelola Produk</a>
+          <a className="btn-outline" href="/seller/orders">Pesanan Saya</a>
+          <a className="btn-outline" href="/seller/warehouses">Gudang</a>
+          <a className="btn-outline" href="/seller/returns">Retur</a>
+          <a className="btn-outline" href="/seller/flash-sales">Flash Sale</a>
+          <a className="btn-outline" href={`/s/${storeSlug}`} target="_blank">Lihat Toko</a>
+          <a className="btn-outline" href="/seller/settings">Pengaturan Toko</a>
+        </div>
       </div>
     </div>
   );

--- a/components/MobileTabBar.tsx
+++ b/components/MobileTabBar.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const tabs = [
+  { href: "/", label: "Beranda", icon: "🏠" },
+  { href: "/cart", label: "Keranjang", icon: "🛒" },
+  { href: "/orders", label: "Pesanan", icon: "📦" },
+  { href: "/notifications", label: "Notifikasi", icon: "🔔" },
+  { href: "/account", label: "Saya", icon: "👤" },
+];
+
+export function MobileTabBar() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="fixed inset-x-0 bottom-0 z-50 border-t border-gray-200 bg-white/95 shadow-[0_-2px_20px_rgba(15,23,42,0.08)] backdrop-blur md:hidden">
+      <div className="mx-auto flex max-w-6xl items-center justify-between px-2 py-2">
+        {tabs.map((tab) => {
+          const isActive = pathname === tab.href || (tab.href !== "/" && pathname.startsWith(tab.href));
+          return (
+            <Link
+              key={tab.href}
+              href={tab.href}
+              className={`flex flex-1 flex-col items-center gap-1 rounded-xl px-1 py-1 text-[11px] font-medium transition ${
+                isActive ? "text-[#f53d2d]" : "text-gray-500 hover:text-[#f53d2d]"
+              }`}
+            >
+              <span className="text-lg">{tab.icon}</span>
+              <span>{tab.label}</span>
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -38,8 +38,8 @@ export function SiteHeader({ user }: SiteHeaderProps) {
   }, [categoryOpen]);
 
   return (
-    <header className="bg-gradient-to-r from-[#f53d2d] via-[#f63] to-[#ff6f3c] text-white shadow"> 
-      <div className="border-b border-white/20">
+    <header className="bg-gradient-to-r from-[#f53d2d] via-[#f63] to-[#ff6f3c] text-white shadow">
+      <div className="hidden border-b border-white/20 md:block">
         <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-2 text-xs">
           <div className="flex items-center gap-4">
             <Link href="/seller/login" className="hover:underline">
@@ -118,7 +118,7 @@ export function SiteHeader({ user }: SiteHeaderProps) {
           </div>
         </div>
       </div>
-      <div className="mx-auto flex max-w-6xl flex-col gap-2 px-4 py-3 md:flex-row md:items-center md:justify-between md:gap-4">
+      <div className="mx-auto hidden w-full max-w-6xl items-center justify-between gap-4 px-4 py-3 md:flex">
         <div className="flex items-center gap-2 md:gap-3">
           <Link href="/" className="text-2xl font-bold tracking-wide md:text-[26px]">
             🛍️ Akay Nusantara
@@ -168,6 +168,54 @@ export function SiteHeader({ user }: SiteHeaderProps) {
             <span aria-hidden>🛒</span>
             Keranjang
           </Link>
+        </div>
+      </div>
+      <div className="mx-auto w-full max-w-6xl px-4 py-3 md:hidden">
+        <div className="flex items-center justify-between">
+          <Link href="/" className="text-lg font-semibold tracking-wide">
+            🛍️ Akay Nusantara
+          </Link>
+          <div className="flex items-center gap-3 text-xl">
+            <Link href="/notifications" aria-label="Notifikasi" className="transition hover:scale-105">
+              🔔
+            </Link>
+            <Link href="/cart" aria-label="Keranjang" className="transition hover:scale-105">
+              🛒
+            </Link>
+            {user ? (
+              <Link href="/account" aria-label="Akun" className="transition hover:scale-105">
+                👤
+              </Link>
+            ) : (
+              <Link href="/seller/login" aria-label="Login" className="transition hover:scale-105">
+                🔑
+              </Link>
+            )}
+          </div>
+        </div>
+        <form className="mt-3 flex items-center gap-2 rounded-full bg-white/95 px-4 py-2 text-sm text-gray-700 shadow-inner" action="/search" method="GET">
+          <span aria-hidden className="text-lg text-[#f53d2d]">🔍</span>
+          <input
+            name="q"
+            type="search"
+            placeholder="Cari produk, toko, dan voucher"
+            className="flex-1 bg-transparent outline-none"
+          />
+          <button type="submit" className="rounded-full bg-[#f53d2d] px-3 py-1 text-xs font-semibold text-white">
+            Cari
+          </button>
+        </form>
+        <div className="mt-3 flex gap-2 overflow-x-auto pb-1 text-[13px] font-medium">
+          {productCategories.slice(0, 8).map((category) => (
+            <Link
+              key={category.slug}
+              href={`/#kategori-${category.slug}`}
+              className="inline-flex flex-shrink-0 items-center gap-1 rounded-full bg-white/15 px-3 py-1 text-white/90 shadow-sm ring-1 ring-white/20"
+            >
+              <span aria-hidden>{category.emoji}</span>
+              <span>{category.name}</span>
+            </Link>
+          ))}
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- add a dedicated mobile bottom tab bar and wire it into the global layout
- refresh the site header and home page mobile sections to mirror the provided inspiration
- redesign the account and seller dashboard pages on mobile with summaries and quick links

## Testing
- not run (project has no lint/test scripts)

------
https://chatgpt.com/codex/tasks/task_e_68e5534063648320ba5296d133a61c74