### PR TITLE
Adjust mobile product detail layout

### DIFF
--- a/app/product/[id]/page.tsx
+++ b/app/product/[id]/page.tsx
@@ -113,6 +113,61 @@ function formatReviewDateTime(value: Date) {
 const HERO_PLACEHOLDER = "https://placehold.co/900x600?text=Produk";
 const THUMB_PLACEHOLDER = "https://placehold.co/300x200?text=Preview";
 
+type IconProps = { className?: string };
+
+function IconChevronLeft({ className }: IconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.8}
+      className={className}
+    >
+      <path d="m15 18-6-6 6-6" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function IconShare({ className }: IconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.8}
+      className={className}
+    >
+      <path d="M4 12v7a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-7" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M16 8 12 4 8 8" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M12 5v10" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function IconShoppingCart({ className }: IconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.8}
+      className={className}
+    >
+      <path
+        d="M4 6h2l1.2 9.6A2 2 0 0 0 9.18 17h7.64a2 2 0 0 0 1.98-1.4L20 8H7"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle cx="9" cy="20" r="1" />
+      <circle cx="17" cy="20" r="1" />
+    </svg>
+  );
+}
+
 export default async function ProductPage({ params }: { params: { id: string } }) {
   const sessionPromise = getSession();
   const now = new Date();
@@ -329,21 +384,76 @@ export default async function ProductPage({ params }: { params: { id: string } }
   ).slice(0, 5);
 
   return (
-    <div className="space-y-10">
+    <div className="space-y-10 pb-36 lg:pb-0">
       <section className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)] xl:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)]">
         <div className="space-y-4">
-          <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white p-4 shadow-sm">
-            <img
-              src={heroImageSrc}
-              alt={product.title}
-              className="w-full rounded-xl object-cover"
-            />
+          <div className="relative overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+            <div className="lg:p-4">
+              <img
+                src={heroImageSrc}
+                alt={product.title}
+                className="aspect-[3/4] w-full object-cover lg:aspect-[4/3] lg:rounded-xl"
+              />
+            </div>
+            <div className="absolute inset-x-0 top-0 flex items-center justify-between p-4 text-white lg:hidden">
+              <Link href="/" aria-label="Kembali">
+                <span className="flex h-10 w-10 items-center justify-center rounded-full bg-black/40 backdrop-blur">
+                  <IconChevronLeft className="h-5 w-5" />
+                </span>
+              </Link>
+              <div className="flex items-center gap-3">
+                <button
+                  type="button"
+                  className="flex h-10 w-10 items-center justify-center rounded-full bg-black/40 backdrop-blur"
+                  aria-label="Bagikan produk"
+                >
+                  <IconShare className="h-5 w-5" />
+                </button>
+                <Link
+                  href="/cart"
+                  className="flex h-10 w-10 items-center justify-center rounded-full bg-black/40 backdrop-blur"
+                  aria-label="Lihat keranjang"
+                >
+                  <IconShoppingCart className="h-5 w-5" />
+                </Link>
+              </div>
+            </div>
           </div>
-          <div className="grid grid-cols-4 gap-3 sm:grid-cols-5">
+          <div className="space-y-3 rounded-2xl border border-gray-200 bg-white p-4 shadow-sm lg:hidden">
+            <div className="flex items-end justify-between gap-3">
+              <div>
+                <div className="text-2xl font-semibold text-orange-600">Rp {formatIDR(salePrice)}</div>
+                {showOriginal && referenceOriginal ? (
+                  <div className="mt-1 flex items-center gap-2 text-xs">
+                    <span className="text-gray-400 line-through">Rp {formatIDR(referenceOriginal)}</span>
+                    {discountPercent ? (
+                      <span className="rounded-full bg-orange-100 px-2 py-0.5 text-[11px] font-semibold text-orange-600">
+                        -{discountPercent}%
+                      </span>
+                    ) : null}
+                  </div>
+                ) : null}
+              </div>
+              <span className="text-xs font-semibold text-gray-500">
+                {soldCount > 0 ? `${formatCompactNumber(soldCount)} terjual` : "Belum ada penjualan"}
+              </span>
+            </div>
+            <h1 className="text-lg font-semibold text-gray-900">{product.title}</h1>
+            <div className="flex flex-wrap items-center gap-2 text-xs text-gray-500">
+              <span className="flex items-center gap-1 text-sm font-semibold text-gray-700">
+                <span className="flex items-center gap-0.5 text-base">{renderStars(ratingValue)}</span>
+                {ratingValue.toFixed(1)}
+              </span>
+              <span>({formatCompactNumber(Math.max(ratingCount, 0))} penilaian)</span>
+              <span>•</span>
+              <span>{formatCompactNumber(favoriteEstimate)} favorit</span>
+            </div>
+          </div>
+          <div className="flex gap-3 overflow-x-auto lg:grid lg:grid-cols-4 lg:gap-3 lg:overflow-visible xl:grid-cols-5">
             {thumbnailImages.map((image, index) => (
               <div
                 key={image.id}
-                className="flex h-20 items-center justify-center overflow-hidden rounded-lg border border-dashed border-gray-200 bg-white"
+                className="flex h-20 min-w-[80px] items-center justify-center overflow-hidden rounded-lg border border-dashed border-gray-200 bg-white"
               >
                 <img
                   src={image.src}
@@ -368,7 +478,7 @@ export default async function ProductPage({ params }: { params: { id: string } }
 
         <div className="space-y-6">
           <div className="space-y-5 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-            <nav className="flex flex-wrap items-center gap-2 text-xs text-gray-500">
+            <nav className="hidden flex-wrap items-center gap-2 text-xs text-gray-500 lg:flex">
               <Link href="/" className="hover:text-orange-500">
                 Beranda
               </Link>
@@ -378,7 +488,7 @@ export default async function ProductPage({ params }: { params: { id: string } }
               <span className="capitalize">{categoryLabel}</span>
             </nav>
 
-            <div className="space-y-2">
+            <div className="hidden space-y-2 lg:block">
               <h1 className="text-2xl font-semibold text-gray-900">{product.title}</h1>
               <div className="flex flex-wrap items-center gap-3 text-sm text-gray-500">
                 <span className="flex items-center gap-1">
@@ -393,7 +503,7 @@ export default async function ProductPage({ params }: { params: { id: string } }
               </div>
             </div>
 
-            <div className="space-y-3 rounded-xl bg-orange-50 p-5">
+            <div className="hidden space-y-3 rounded-xl bg-orange-50 p-5 lg:block">
               <div className="flex flex-wrap items-end gap-4">
                 <div className="text-3xl font-semibold text-orange-600">Rp {formatIDR(salePrice)}</div>
                 {showOriginal && referenceOriginal && (
@@ -463,6 +573,17 @@ export default async function ProductPage({ params }: { params: { id: string } }
                 </div>
               </div>
 
+              <div className="hidden lg:block">
+                <AddToCartForm
+                  productId={product.id}
+                  title={product.title}
+                  price={salePrice}
+                  sellerId={product.sellerId}
+                  stock={product.stock}
+                  imageUrl={primaryImage}
+                  isLoggedIn={Boolean(currentUserId)}
+                />
+              </div>
               <AddToCartForm
                 productId={product.id}
                 title={product.title}
@@ -471,6 +592,7 @@ export default async function ProductPage({ params }: { params: { id: string } }
                 stock={product.stock}
                 imageUrl={primaryImage}
                 isLoggedIn={Boolean(currentUserId)}
+                variant="mobile"
               />
             </div>
           </div>

--- a/components/AddToCartForm.tsx
+++ b/components/AddToCartForm.tsx
@@ -10,6 +10,7 @@ export type AddToCartFormProps = {
   stock: number;
   imageUrl?: string | null;
   isLoggedIn?: boolean;
+  variant?: "default" | "mobile";
 };
 
 type CartItem = {
@@ -49,6 +50,7 @@ export function AddToCartForm({
   stock,
   imageUrl,
   isLoggedIn = false,
+  variant = "default",
 }: AddToCartFormProps) {
   const [quantity, setQuantity] = useState(1);
   const [status, setStatus] = useState<"idle" | "success" | "unauthenticated">("idle");
@@ -84,6 +86,66 @@ export function AddToCartForm({
     }
     setQuantity(Math.max(1, Math.floor(value)));
   }, []);
+
+  if (variant === "mobile") {
+    return (
+      <form className="space-y-4 lg:hidden" onSubmit={handleSubmit}>
+        <input type="hidden" name="productId" value={productId} />
+        <div className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm">
+          <label className="mb-3 block text-sm font-semibold text-gray-700" htmlFor="quantity-input-mobile">
+            Jumlah
+          </label>
+          <div className="flex flex-wrap items-center gap-3">
+            <input
+              id="quantity-input-mobile"
+              type="number"
+              name="qty"
+              value={quantity}
+              min={1}
+              onChange={handleChange}
+              className="h-11 w-24 rounded-lg border border-gray-300 px-3 text-center text-sm focus:border-orange-500 focus:outline-none"
+            />
+            <span className="text-xs text-gray-500">Stok tersedia: {stock}</span>
+          </div>
+        </div>
+        <div className="pointer-events-none fixed inset-x-0 bottom-0 z-50 px-4 pb-4">
+          <div className="pointer-events-auto space-y-3 rounded-3xl border border-orange-100 bg-white p-4 shadow-xl shadow-black/5">
+            {status === "success" ? (
+              <div className="rounded-xl border border-emerald-100 bg-emerald-50 px-3 py-2 text-xs text-emerald-700">
+                Produk berhasil ditambahkan ke keranjang. <a className="font-semibold underline" href="/cart">Lihat keranjang</a>.
+              </div>
+            ) : null}
+            {status === "unauthenticated" ? (
+              <div className="rounded-xl border border-red-100 bg-red-50 px-3 py-2 text-xs text-red-600">
+                Silahkan login jika ingin memasukan ke keranjang.
+              </div>
+            ) : null}
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                className="flex h-12 w-12 items-center justify-center rounded-full border border-gray-200 text-lg text-gray-600 transition hover:border-orange-200 hover:text-orange-500"
+                aria-label="Tambahkan ke favorit"
+              >
+                ❤
+              </button>
+              <button
+                type="submit"
+                className="flex-1 rounded-full bg-orange-100 px-4 py-3 text-sm font-semibold text-orange-600 transition hover:bg-orange-200"
+              >
+                Masukkan Keranjang
+              </button>
+              <a
+                href="/checkout"
+                className="flex-[1.3] rounded-full bg-orange-500 px-4 py-3 text-center text-sm font-semibold text-white transition hover:bg-orange-600"
+              >
+                Beli Sekarang
+              </a>
+            </div>
+          </div>
+        </div>
+      </form>
+    );
+  }
 
   return (
     <form className="space-y-4 rounded-xl border border-gray-200 bg-white p-4" onSubmit={handleSubmit}>

--- a/components/BackButton.tsx
+++ b/components/BackButton.tsx
@@ -34,7 +34,10 @@ export function BackButton() {
 
   const label = useMemo(() => (canGoBack ? "Kembali" : "Beranda"), [canGoBack]);
 
-  if (pathname === "/") {
+  const isHome = pathname === "/";
+  const isProductPage = pathname?.startsWith("/product/") ?? false;
+
+  if (isHome || isProductPage) {
     return null;
   }
 

--- a/components/MobileTabBar.tsx
+++ b/components/MobileTabBar.tsx
@@ -14,6 +14,10 @@ const tabs = [
 export function MobileTabBar() {
   const pathname = usePathname();
 
+  if (pathname?.startsWith("/product/")) {
+    return null;
+  }
+
   return (
     <nav className="fixed inset-x-0 bottom-0 z-50 border-t border-gray-200 bg-white/95 shadow-[0_-2px_20px_rgba(15,23,42,0.08)] backdrop-blur md:hidden">
       <div className="mx-auto flex max-w-6xl items-center justify-between px-2 py-2">

--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useState, useRef, useEffect } from "react";
+import { usePathname } from "next/navigation";
 import { SessionUser } from "@/lib/session";
 import { productCategories } from "@/lib/categories";
 
@@ -10,6 +11,8 @@ type SiteHeaderProps = {
 };
 
 export function SiteHeader({ user }: SiteHeaderProps) {
+  const pathname = usePathname();
+  const hideMobileHeader = pathname?.startsWith("/product/") ?? false;
   const [open, setOpen] = useState(false);
   const [categoryOpen, setCategoryOpen] = useState(false);
   const [cartCount, setCartCount] = useState(0);
@@ -245,59 +248,61 @@ export function SiteHeader({ user }: SiteHeaderProps) {
           </Link>
         </div>
       </div>
-      <div className="mx-auto w-full max-w-6xl px-4 py-3 md:hidden">
-        <div className="flex items-center justify-between">
-          <Link href="/" className="text-lg font-semibold tracking-wide">
-            🛍️ Akay Nusantara
-          </Link>
-          <div className="flex items-center gap-3 text-xl">
-            <Link href="/notifications" aria-label="Notifikasi" className="transition hover:scale-105">
-              🔔
+      {!hideMobileHeader ? (
+        <div className="mx-auto w-full max-w-6xl px-4 py-3 md:hidden">
+          <div className="flex items-center justify-between">
+            <Link href="/" className="text-lg font-semibold tracking-wide">
+              🛍️ Akay Nusantara
             </Link>
-            <Link href="/cart" aria-label="Keranjang" className="relative transition hover:scale-105">
-              🛒
-              {cartCount > 0 ? (
-                <span className="absolute -right-2 -top-2 inline-flex h-4 min-w-[18px] items-center justify-center rounded-full bg-white text-[10px] font-semibold text-[#f53d2d]">
-                  {cartCount}
-                </span>
-              ) : null}
-            </Link>
-            {user ? (
-              <Link href="/account" aria-label="Akun" className="transition hover:scale-105">
-                👤
+            <div className="flex items-center gap-3 text-xl">
+              <Link href="/notifications" aria-label="Notifikasi" className="transition hover:scale-105">
+                🔔
               </Link>
-            ) : (
-              <Link href="/seller/login" aria-label="Login" className="transition hover:scale-105">
-                🔑
+              <Link href="/cart" aria-label="Keranjang" className="relative transition hover:scale-105">
+                🛒
+                {cartCount > 0 ? (
+                  <span className="absolute -right-2 -top-2 inline-flex h-4 min-w-[18px] items-center justify-center rounded-full bg-white text-[10px] font-semibold text-[#f53d2d]">
+                    {cartCount}
+                  </span>
+                ) : null}
               </Link>
-            )}
+              {user ? (
+                <Link href="/account" aria-label="Akun" className="transition hover:scale-105">
+                  👤
+                </Link>
+              ) : (
+                <Link href="/seller/login" aria-label="Login" className="transition hover:scale-105">
+                  🔑
+                </Link>
+              )}
+            </div>
+          </div>
+          <form className="mt-3 flex items-center gap-2 rounded-full bg-white/95 px-4 py-2 text-sm text-gray-700 shadow-inner" action="/search" method="GET">
+            <span aria-hidden className="text-lg text-[#f53d2d]">🔍</span>
+            <input
+              name="q"
+              type="search"
+              placeholder="Cari produk, toko, dan voucher"
+              className="flex-1 bg-transparent outline-none"
+            />
+            <button type="submit" className="rounded-full bg-[#f53d2d] px-3 py-1 text-xs font-semibold text-white">
+              Cari
+            </button>
+          </form>
+          <div className="mt-3 flex gap-2 overflow-x-auto pb-1 text-[13px] font-medium">
+            {productCategories.slice(0, 8).map((category) => (
+              <Link
+                key={category.slug}
+                href={`/categories/${category.slug}`}
+                className="inline-flex flex-shrink-0 items-center gap-1 rounded-full bg-white/15 px-3 py-1 text-white/90 shadow-sm ring-1 ring-white/20"
+              >
+                <span aria-hidden>{category.emoji}</span>
+                <span>{category.name}</span>
+              </Link>
+            ))}
           </div>
         </div>
-        <form className="mt-3 flex items-center gap-2 rounded-full bg-white/95 px-4 py-2 text-sm text-gray-700 shadow-inner" action="/search" method="GET">
-          <span aria-hidden className="text-lg text-[#f53d2d]">🔍</span>
-          <input
-            name="q"
-            type="search"
-            placeholder="Cari produk, toko, dan voucher"
-            className="flex-1 bg-transparent outline-none"
-          />
-          <button type="submit" className="rounded-full bg-[#f53d2d] px-3 py-1 text-xs font-semibold text-white">
-            Cari
-          </button>
-        </form>
-        <div className="mt-3 flex gap-2 overflow-x-auto pb-1 text-[13px] font-medium">
-          {productCategories.slice(0, 8).map((category) => (
-            <Link
-              key={category.slug}
-              href={`/categories/${category.slug}`}
-              className="inline-flex flex-shrink-0 items-center gap-1 rounded-full bg-white/15 px-3 py-1 text-white/90 shadow-sm ring-1 ring-white/20"
-            >
-              <span aria-hidden>{category.emoji}</span>
-              <span>{category.name}</span>
-            </Link>
-          ))}
-        </div>
-      </div>
+      ) : null}
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- overhaul the product detail hero on mobile with overlay controls and reorganized price/title blocks
- introduce a mobile add-to-cart variant that anchors purchase actions in a bottom bar while reusing existing cart logic
- gate desktop-only breadcrumbs and pricing blocks so the large-screen experience remains unchanged
- hide the site header, back button, and persistent tab bar on product detail pages when viewed on mobile

## Testing
- npm run build *(passes with warning: database unavailable for Prisma migrate)*

------
https://chatgpt.com/codex/tasks/task_e_68e5869b4a608320a45b29e5fdb28151