### PR TITLE
feat: adopt army green theme with css variable dark mode

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -87,7 +87,7 @@ export default async function AccountPage({ searchParams }: AccountPageProps) {
   return (
     <div className="mx-auto max-w-5xl space-y-8 px-4 py-8">
       <div className="space-y-4 md:hidden">
-        <div className="relative rounded-3xl bg-gradient-to-br from-[#f53d2d] via-[#ff6f3c] to-[#ff9364] px-6 py-6 text-white shadow-lg">
+        <div className="relative rounded-3xl bg-gradient-to-br from-primary via-primary-bright to-primary-soft px-6 py-6 text-white shadow-lg">
           <form method="POST" action="/api/auth/logout" className="absolute right-4 top-4">
             <button
               type="submit"
@@ -126,7 +126,7 @@ export default async function AccountPage({ searchParams }: AccountPageProps) {
               <h2 className="text-lg font-semibold text-gray-900">Pesanan Saya</h2>
               <p className="text-xs text-gray-500">Lacak status terbaru transaksi Anda.</p>
             </div>
-            <Link href="/orders" className="text-xs font-semibold text-[#f53d2d]">
+            <Link href="/orders" className="text-xs font-semibold text-primary">
               Lihat riwayat
             </Link>
           </div>
@@ -139,7 +139,7 @@ export default async function AccountPage({ searchParams }: AccountPageProps) {
               >
                 <span className="text-xl">{item.icon}</span>
                 <span className="text-xs text-gray-900">{item.label}</span>
-                <span className="text-[11px] font-semibold text-[#f53d2d]">{item.value}</span>
+                <span className="text-[11px] font-semibold text-primary">{item.value}</span>
               </Link>
             ))}
             <Link
@@ -148,14 +148,14 @@ export default async function AccountPage({ searchParams }: AccountPageProps) {
             >
               <span className="text-xl">🚫</span>
               <span className="text-xs text-gray-900">Dibatalkan</span>
-              <span className="text-[11px] font-semibold text-[#f53d2d]">{cancelledOrders}</span>
+              <span className="text-[11px] font-semibold text-primary">{cancelledOrders}</span>
             </Link>
           </div>
         </div>
         <div className="grid grid-cols-2 gap-3 text-xs font-semibold text-gray-700">
           <Link
             href="/seller/dashboard"
-            className="col-span-2 flex items-center justify-between rounded-2xl bg-gradient-to-r from-[#f53d2d] via-[#ff6f3c] to-[#ff9364] px-5 py-4 text-white shadow-md"
+            className="col-span-2 flex items-center justify-between rounded-2xl bg-gradient-to-r from-primary via-primary-bright to-primary-soft px-5 py-4 text-primary-foreground shadow-md"
           >
             <div className="flex items-center gap-3 text-left">
               <span className="text-xl">🛍️</span>
@@ -241,7 +241,7 @@ export default async function AccountPage({ searchParams }: AccountPageProps) {
               type="url"
               placeholder="https://contoh.com/foto.jpg"
               defaultValue={account.avatarUrl ?? ""}
-              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
             />
             <p className="text-xs text-gray-500">Gunakan tautan gambar langsung berformat http atau https.</p>
           </div>
@@ -257,7 +257,7 @@ export default async function AccountPage({ searchParams }: AccountPageProps) {
               placeholder="nama-pengguna"
               minLength={3}
               defaultValue={account.username ?? ""}
-              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
             />
             <p className="text-xs text-gray-500">Username digunakan untuk identitas publik di masa mendatang.</p>
           </div>
@@ -273,7 +273,7 @@ export default async function AccountPage({ searchParams }: AccountPageProps) {
               required
               minLength={3}
               defaultValue={account.name}
-              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
             />
           </div>
 
@@ -287,7 +287,7 @@ export default async function AccountPage({ searchParams }: AccountPageProps) {
               type="email"
               required
               defaultValue={account.email}
-              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
             />
           </div>
 
@@ -302,7 +302,7 @@ export default async function AccountPage({ searchParams }: AccountPageProps) {
               inputMode="tel"
               placeholder="08xxxxxxxxxx"
               defaultValue={account.phoneNumber ?? ""}
-              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
             />
             <p className="text-xs text-gray-500">Masukkan nomor aktif untuk memudahkan konfirmasi pesanan.</p>
           </div>
@@ -315,7 +315,7 @@ export default async function AccountPage({ searchParams }: AccountPageProps) {
               id="gender"
               name="gender"
               defaultValue={(account.gender as Gender | null) ?? ""}
-              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
             >
               {GENDER_OPTIONS.map((option) => (
                 <option key={option.value || "empty"} value={option.value}>
@@ -376,7 +376,7 @@ export default async function AccountPage({ searchParams }: AccountPageProps) {
                 key={address.id}
                 className={`rounded-xl border p-5 shadow-sm transition ${
                   address.id === editingAddress?.id
-                    ? "border-[#f53d2d] ring-2 ring-[#f53d2d]/20"
+                    ? "border-primary ring-2 ring-primary/20"
                     : "border-gray-200"
                 }`}
               >
@@ -393,7 +393,7 @@ export default async function AccountPage({ searchParams }: AccountPageProps) {
                     </span>
                     <a
                       href={`/account?editAddress=${encodeURIComponent(address.id)}`}
-                      className="inline-flex items-center gap-1 rounded-full border border-gray-200 px-3 py-1 text-xs font-medium text-gray-600 transition hover:border-[#f53d2d] hover:text-[#f53d2d]"
+                      className="inline-flex items-center gap-1 rounded-full border border-gray-200 px-3 py-1 text-xs font-medium text-gray-600 transition hover:border-primary hover:text-primary"
                     >
                       Edit
                     </a>
@@ -436,7 +436,7 @@ export default async function AccountPage({ searchParams }: AccountPageProps) {
                 type="text"
                 required
                 defaultValue={editingAddress.fullName}
-                className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+                className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
               />
             </div>
 
@@ -451,7 +451,7 @@ export default async function AccountPage({ searchParams }: AccountPageProps) {
                 inputMode="tel"
                 required
                 defaultValue={editingAddress.phoneNumber}
-                className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+                className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
               />
             </div>
 
@@ -473,7 +473,7 @@ export default async function AccountPage({ searchParams }: AccountPageProps) {
                 required
                 pattern="\d{4,10}"
                 defaultValue={editingAddress.postalCode}
-                className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+                className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
               />
             </div>
 
@@ -487,7 +487,7 @@ export default async function AccountPage({ searchParams }: AccountPageProps) {
                 required
                 rows={3}
                 defaultValue={editingAddress.addressLine}
-                className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+                className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
               />
             </div>
 
@@ -501,7 +501,7 @@ export default async function AccountPage({ searchParams }: AccountPageProps) {
                 rows={2}
                 defaultValue={editingAddress.additionalInfo ?? ""}
                 placeholder="Contoh: Patokan rumah warna hijau, blok B nomor 3"
-                className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+                className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
               />
             </div>
 
@@ -533,7 +533,7 @@ export default async function AccountPage({ searchParams }: AccountPageProps) {
               name="fullName"
               type="text"
               required
-              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
             />
           </div>
 
@@ -547,7 +547,7 @@ export default async function AccountPage({ searchParams }: AccountPageProps) {
               type="tel"
               inputMode="tel"
               required
-              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
             />
           </div>
 
@@ -563,7 +563,7 @@ export default async function AccountPage({ searchParams }: AccountPageProps) {
               type="text"
               required
               pattern="\d{4,10}"
-              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
             />
           </div>
 
@@ -576,7 +576,7 @@ export default async function AccountPage({ searchParams }: AccountPageProps) {
               name="addressLine"
               required
               rows={3}
-              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
             />
           </div>
 
@@ -589,7 +589,7 @@ export default async function AccountPage({ searchParams }: AccountPageProps) {
               name="additionalInfo"
               rows={2}
               placeholder="Contoh: Patokan rumah warna hijau, blok B nomor 3"
-              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30"
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
             />
           </div>
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,14 +2,73 @@
 @tailwind components;
 @tailwind utilities;
 
-.badge{ @apply inline-block text-xs px-2 py-0.5 rounded-full; }
-.badge-pending{ @apply bg-amber-100 text-amber-700; }
-.badge-paid{ @apply bg-emerald-100 text-emerald-700; }
-.badge-danger{ @apply bg-red-100 text-red-700; }
-.badge-packed{ @apply bg-blue-100 text-blue-700; }
-.badge-shipped{ @apply bg-purple-100 text-purple-700; }
-.badge-delivered{ @apply bg-green-100 text-green-700; }
+@layer base {
+  :root {
+    color-scheme: light;
+    --background: 0 0% 100%;
+    --foreground: 222 47% 11%;
+    --muted: 60 4% 95%;
+    --muted-foreground: 222 20% 40%;
+    --border: 210 24% 88%;
+    --accent: 83 47% 88%;
+    --accent-foreground: 80 33% 20%;
+    --primary: 69 44% 23%;
+    --primary-foreground: 0 0% 100%;
+    --primary-soft: 69 45% 92%;
+    --primary-bright: 72 52% 34%;
+    --primary-strong: 69 44% 16%;
+    --primary-ring: 69 44% 35%;
+  }
 
-.btn-primary { @apply bg-army text-white rounded px-4 py-2 hover:opacity-90; }
-.btn-outline { @apply border border-army text-army rounded px-4 py-2 hover:bg-army hover:text-white; }
-.link { @apply text-army hover:opacity-80 underline; }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      color-scheme: dark;
+      --background: 222 47% 11%;
+      --foreground: 210 40% 96%;
+      --muted: 215 28% 20%;
+      --muted-foreground: 217 15% 70%;
+      --border: 215 27% 26%;
+      --accent: 82 34% 25%;
+      --accent-foreground: 82 63% 80%;
+      --primary: 69 44% 26%;
+      --primary-foreground: 0 0% 100%;
+      --primary-soft: 74 36% 20%;
+      --primary-bright: 82 47% 45%;
+      --primary-strong: 69 46% 18%;
+      --primary-ring: 77 43% 65%;
+    }
+  }
+
+  .dark {
+    color-scheme: dark;
+    --background: 222 47% 11%;
+    --foreground: 210 40% 96%;
+    --muted: 215 28% 20%;
+    --muted-foreground: 217 15% 70%;
+    --border: 215 27% 26%;
+    --accent: 82 34% 25%;
+    --accent-foreground: 82 63% 80%;
+    --primary: 69 44% 26%;
+    --primary-foreground: 0 0% 100%;
+    --primary-soft: 74 36% 20%;
+    --primary-bright: 82 47% 45%;
+    --primary-strong: 69 46% 18%;
+    --primary-ring: 77 43% 65%;
+  }
+
+  body {
+    @apply bg-background text-foreground antialiased transition-colors duration-300;
+  }
+}
+
+.badge { @apply inline-block rounded-full px-2 py-0.5 text-xs; }
+.badge-pending { @apply bg-amber-100 text-amber-700; }
+.badge-paid { @apply bg-emerald-100 text-emerald-700; }
+.badge-danger { @apply bg-red-100 text-red-700; }
+.badge-packed { @apply bg-blue-100 text-blue-700; }
+.badge-shipped { @apply bg-purple-100 text-purple-700; }
+.badge-delivered { @apply bg-green-100 text-green-700; }
+
+.btn-primary { @apply rounded bg-primary px-4 py-2 font-semibold text-primary-foreground transition hover:bg-primary-strong; }
+.btn-outline { @apply rounded border border-primary text-primary transition hover:bg-primary hover:text-primary-foreground; }
+.link { @apply underline decoration-primary/40 text-primary transition hover:text-primary-strong; }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,8 +19,8 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   const user = await getSessionUser();
 
   return (
-    <html lang="id">
-      <body className="bg-gray-50 text-gray-900">
+    <html lang="id" className="h-full">
+      <body className="min-h-screen bg-background text-foreground transition-colors">
         <SiteHeader user={user} />
         <main className="mx-auto max-w-6xl px-4 pb-28 pt-6 md:pb-12">
           <div className="mb-6 flex justify-between">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -139,11 +139,11 @@ export default async function HomePage() {
       <PromoSlider slides={slides.length > 0 ? slides : fallbackSlides} />
 
       <div className="space-y-4 md:hidden">
-        <div className="rounded-3xl bg-gradient-to-br from-white/95 via-white/90 to-white/70 px-4 py-4 text-gray-900 shadow-xl shadow-[#f53d2d]/10 ring-1 ring-white/70">
+        <div className="rounded-3xl bg-gradient-to-br from-white/95 via-white/90 to-white/70 px-4 py-4 text-gray-900 shadow-xl shadow-[0_20px_50px_rgba(75,83,32,0.1)] ring-1 ring-white/70">
           <div className="flex items-center justify-between">
             <div>
               <p className="text-xs uppercase tracking-wide text-gray-500">Voucher Pilihan</p>
-              <p className="text-lg font-semibold text-[#f53d2d]">
+              <p className="text-lg font-semibold text-primary">
                 {highlightedVoucher ? highlightedVoucher.code : "Diskon Spesial"}
               </p>
               <p className="text-xs text-gray-500">
@@ -157,7 +157,7 @@ export default async function HomePage() {
                 voucherId={highlightedVoucher.id}
                 voucherCode={highlightedVoucher.code}
                 size="sm"
-                color="salmon"
+                color="primary"
                 className="shadow"
               >
                 Klaim
@@ -165,7 +165,7 @@ export default async function HomePage() {
             ) : (
               <Link
                 href="/promo"
-                className="rounded-full bg-[#f53d2d] px-4 py-2 text-xs font-semibold text-white shadow"
+                className="rounded-full bg-primary px-4 py-2 text-xs font-semibold text-primary-foreground shadow"
               >
                 Jelajahi
               </Link>

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -49,7 +49,7 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
 
   return (
     <div className="mx-auto max-w-6xl px-4 py-10">
-      <div className="rounded-3xl bg-gradient-to-r from-[#f53d2d] via-[#ff6f3c] to-[#ff9364] p-[1px] shadow-lg">
+      <div className="rounded-3xl bg-gradient-to-r from-primary via-primary-bright to-primary-soft p-[1px] shadow-lg">
         <div className="rounded-3xl bg-white p-6">
           <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
             <div>
@@ -66,7 +66,7 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
               method="GET"
             >
               <div className="flex flex-1 items-center gap-2 rounded-full bg-gray-100 px-4 py-2 text-sm text-gray-700 shadow-inner">
-                <span aria-hidden className="text-lg text-[#f53d2d]">🔍</span>
+                <span aria-hidden className="text-lg text-primary">🔍</span>
                 <input
                   name="q"
                   defaultValue={query}
@@ -78,7 +78,7 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
               </div>
               <button
                 type="submit"
-                className="inline-flex items-center justify-center rounded-full bg-[#f53d2d] px-5 py-2 text-sm font-semibold text-white shadow transition hover:bg-[#d73224]"
+                className="inline-flex items-center justify-center rounded-full bg-primary px-5 py-2 text-sm font-semibold text-primary-foreground shadow transition hover:bg-primary-strong"
               >
                 Cari
               </button>

--- a/app/seller/dashboard/page.tsx
+++ b/app/seller/dashboard/page.tsx
@@ -180,7 +180,7 @@ export default async function Dashboard() {
   return (
     <div className="space-y-6">
       <div className="space-y-4 md:hidden">
-        <div className="rounded-3xl bg-gradient-to-br from-[#f53d2d] via-[#ff6f3c] to-[#ff8f59] px-6 py-6 text-white shadow-xl">
+        <div className="rounded-3xl bg-gradient-to-br from-primary via-primary-bright to-primary-soft px-6 py-6 text-primary-foreground shadow-xl">
           <div className="flex items-start justify-between gap-3">
             <div className="space-y-1">
               <p className="text-xs uppercase tracking-wider text-white/70">Dashboard Seller</p>
@@ -200,7 +200,7 @@ export default async function Dashboard() {
             </div>
             <form method="POST" action="/api/seller/store/toggle" className="flex-shrink-0">
               <input type="hidden" name="status" value={storeIsOnline ? "offline" : "online"} />
-              <button className="rounded-full bg-white px-4 py-2 text-xs font-semibold text-[#f53d2d] shadow">
+              <button className="rounded-full bg-white px-4 py-2 text-xs font-semibold text-primary shadow">
                 {storeIsOnline ? "Tutup Toko" : "Buka Toko"}
               </button>
             </form>
@@ -217,25 +217,25 @@ export default async function Dashboard() {
         <div className="grid grid-cols-2 gap-3">
           <div className="rounded-2xl bg-white p-4 text-gray-900 shadow-sm">
             <p className="text-xs text-gray-500">Produk Aktif</p>
-            <p className="text-xl font-semibold text-[#f53d2d]">{productCount}</p>
+            <p className="text-xl font-semibold text-primary">{productCount}</p>
           </div>
           <div className="rounded-2xl bg-white p-4 text-gray-900 shadow-sm">
             <p className="text-xs text-gray-500">Pesanan Unik</p>
-            <p className="text-xl font-semibold text-[#f53d2d]">{ordersCount}</p>
+            <p className="text-xl font-semibold text-primary">{ordersCount}</p>
           </div>
           <div className="rounded-2xl bg-white p-4 text-gray-900 shadow-sm">
             <p className="text-xs text-gray-500">Omzet (Paid)</p>
-            <p className="text-xl font-semibold text-[#f53d2d]">Rp {new Intl.NumberFormat("id-ID").format(revenueTotal)}</p>
+            <p className="text-xl font-semibold text-primary">Rp {new Intl.NumberFormat("id-ID").format(revenueTotal)}</p>
           </div>
           <div className="rounded-2xl bg-white p-4 text-gray-900 shadow-sm">
             <p className="text-xs text-gray-500">Permintaan Retur</p>
-            <p className="text-xl font-semibold text-[#f53d2d]">{returnRequestCount}</p>
+            <p className="text-xl font-semibold text-primary">{returnRequestCount}</p>
           </div>
         </div>
         <div className="rounded-3xl bg-white p-5 shadow-sm">
           <div className="flex items-center justify-between">
             <h2 className="text-base font-semibold text-gray-900">Status Pesanan</h2>
-            <Link href="/seller/orders" className="text-xs font-semibold text-[#f53d2d]">
+            <Link href="/seller/orders" className="text-xs font-semibold text-primary">
               Lihat Semua
             </Link>
           </div>
@@ -248,7 +248,7 @@ export default async function Dashboard() {
               >
                 <span className="text-xl">{item.icon}</span>
                 <span className="text-xs text-gray-900">{item.label}</span>
-                <span className="text-[11px] font-semibold text-[#f53d2d]">{item.value}</span>
+                <span className="text-[11px] font-semibold text-primary">{item.value}</span>
               </Link>
             ))}
           </div>
@@ -256,7 +256,7 @@ export default async function Dashboard() {
         <div className="rounded-3xl bg-white p-5 shadow-sm">
           <div className="flex items-center justify-between">
             <h2 className="text-base font-semibold text-gray-900">Alat Toko</h2>
-            <Link href="/seller/settings" className="text-xs font-semibold text-[#f53d2d]">
+            <Link href="/seller/settings" className="text-xs font-semibold text-primary">
               Selengkapnya
             </Link>
           </div>
@@ -309,7 +309,7 @@ export default async function Dashboard() {
                 gudang tertentu.
               </div>
             )}
-            <a className="text-sm font-semibold text-[#f53d2d] hover:text-[#d63b22]" href="/seller/settings">
+            <a className="text-sm font-semibold text-primary hover:text-primary-strong" href="/seller/settings">
               Atur nama &amp; alamat toko →
             </a>
           </div>
@@ -344,7 +344,7 @@ export default async function Dashboard() {
         </div>
         <div className="grid grid-cols-5 gap-3 rounded border bg-white p-4">
           {sellerOrderSummary.map((item) => (
-            <a key={item.label} href={item.href} className="flex flex-col items-center gap-2 text-sm text-gray-600 hover:text-[#f53d2d]">
+            <a key={item.label} href={item.href} className="flex flex-col items-center gap-2 text-sm text-gray-600 hover:text-primary">
               <span className="text-xl">{item.icon}</span>
               <span className="font-semibold text-gray-900">{item.value}</span>
               <span className="text-xs">{item.label}</span>

--- a/app/seller/flash-sales/page.tsx
+++ b/app/seller/flash-sales/page.tsx
@@ -165,7 +165,7 @@ export default async function SellerFlashSalesPage({
             </label>
 
             <div className="flex items-center justify-end md:col-span-2">
-              <button className="rounded-full bg-[#f53d2d] px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[#d73224]">
+              <button className="rounded-full bg-primary px-5 py-2 text-sm font-semibold text-primary-foreground shadow-sm transition hover:bg-primary-strong">
                 Simpan Flash Sale
               </button>
             </div>
@@ -213,7 +213,7 @@ export default async function SellerFlashSalesPage({
                   {referenceOriginal > basePrice ? (
                     <p className="text-gray-400 line-through">Harga sebelum diskon: Rp {formatIDR(referenceOriginal)}</p>
                   ) : null}
-                  <p className="mt-1 text-sm font-semibold text-[#f53d2d]">
+                  <p className="mt-1 text-sm font-semibold text-primary">
                     Diskon {sale.discountPercent}% • Harga flash Rp {formatIDR(salePrice)}
                   </p>
                 </div>

--- a/app/seller/login/page.tsx
+++ b/app/seller/login/page.tsx
@@ -39,12 +39,12 @@ export default async function SellerLogin({
 
   return (
     <div className="mx-auto w-full max-w-5xl">
-      <div className="relative overflow-hidden rounded-[36px] bg-gradient-to-br from-[#f53d2d] via-[#ff7243] to-[#ff9061] p-1 shadow-2xl">
+      <div className="relative overflow-hidden rounded-[36px] bg-gradient-to-br from-primary via-primary-bright to-primary-soft p-1 shadow-2xl">
         <div className="relative flex flex-col gap-10 rounded-[34px] bg-white/90 p-6 lg:flex-row lg:p-10">
-          <div className="relative hidden min-h-[420px] flex-1 flex-col justify-between overflow-hidden rounded-[28px] bg-gradient-to-br from-[#f53d2d] to-[#ff6636] p-10 text-white lg:flex">
+          <div className="relative hidden min-h-[420px] flex-1 flex-col justify-between overflow-hidden rounded-[28px] bg-gradient-to-br from-primary to-primary-bright p-10 text-white lg:flex">
             <div className="space-y-6">
               <div className="flex items-center gap-4">
-                <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-white text-3xl font-bold text-[#f53d2d]">
+                <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-white text-3xl font-bold text-primary">
                   A
                 </div>
                 <div>
@@ -79,7 +79,7 @@ export default async function SellerLogin({
               <span>Masuk</span>
               <a
                 href="mailto:support@akay.id"
-                className="font-medium text-[#f53d2d] hover:text-[#d63b22]"
+                className="font-medium text-primary hover:text-primary-strong"
               >
                 Butuh bantuan?
               </a>
@@ -110,7 +110,7 @@ export default async function SellerLogin({
                   name="email"
                   required
                   placeholder="contoh@email.com"
-                  className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/40"
+                  className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
                 />
               </div>
               <div className="space-y-1">
@@ -123,16 +123,16 @@ export default async function SellerLogin({
                   name="password"
                   required
                   placeholder="Masukkan password"
-                  className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/40"
+                  className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
                 />
               </div>
               <div className="flex items-center justify-between text-sm">
-                <Link href="/seller/forgot-password" className="font-medium text-[#f53d2d] hover:text-[#d63b22]">
+                <Link href="/seller/forgot-password" className="font-medium text-primary hover:text-primary-strong">
                   Lupa password?
                 </Link>
               </div>
               <button
-                className="w-full rounded-xl bg-[#f53d2d] px-4 py-3 text-sm font-semibold uppercase tracking-wide text-white shadow-lg shadow-[#f53d2d]/30 transition hover:bg-[#e13a24] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/50"
+                className="w-full rounded-xl bg-primary px-4 py-3 text-sm font-semibold uppercase tracking-wide text-primary-foreground shadow-lg shadow-[0_12px_30px_rgba(75,83,32,0.3)] transition hover:bg-primary-strong focus:outline-none focus:ring-2 focus:ring-primary/50"
               >
                 Log in
               </button>
@@ -147,13 +147,13 @@ export default async function SellerLogin({
             <div className="grid gap-3 text-sm">
               <button
                 type="button"
-                className="flex items-center justify-center gap-3 rounded-xl border border-gray-200 bg-white px-4 py-3 font-medium text-gray-700 transition hover:border-[#f53d2d]/40 hover:text-[#f53d2d]"
+                className="flex items-center justify-center gap-3 rounded-xl border border-gray-200 bg-white px-4 py-3 font-medium text-gray-700 transition hover:border-primary/40 hover:text-primary"
               >
                 Masuk dengan Facebook
               </button>
               <a
                 href="/api/auth/google"
-                className="flex items-center justify-center gap-3 rounded-xl border border-gray-200 bg-white px-4 py-3 text-center font-medium text-gray-700 transition hover:border-[#f53d2d]/40 hover:text-[#f53d2d]"
+                className="flex items-center justify-center gap-3 rounded-xl border border-gray-200 bg-white px-4 py-3 text-center font-medium text-gray-700 transition hover:border-primary/40 hover:text-primary"
               >
                 Masuk dengan Google
               </a>
@@ -161,7 +161,7 @@ export default async function SellerLogin({
 
             <div className="mt-6 text-center text-sm text-gray-500">
               Baru di Akay Nusantara?{" "}
-              <Link href="/seller/register" className="font-semibold text-[#f53d2d] hover:text-[#d63b22]">
+              <Link href="/seller/register" className="font-semibold text-primary hover:text-primary-strong">
                 Daftar
               </Link>
             </div>

--- a/app/seller/onboarding/page.tsx
+++ b/app/seller/onboarding/page.tsx
@@ -51,9 +51,9 @@ export default async function SellerOnboarding() {
 
   return (
     <div className="mx-auto w-full max-w-4xl space-y-8">
-      <header className="rounded-3xl bg-gradient-to-br from-[#f53d2d] to-[#ff7243] p-[1px] shadow-xl">
+      <header className="rounded-3xl bg-gradient-to-br from-primary to-primary-bright p-[1px] shadow-xl">
         <div className="rounded-[34px] bg-white p-8 shadow-inner">
-          <p className="text-sm font-semibold uppercase tracking-widest text-[#f53d2d]">Onboarding Seller</p>
+          <p className="text-sm font-semibold uppercase tracking-widest text-primary">Onboarding Seller</p>
           <h1 className="mt-3 text-3xl font-bold text-gray-900">Mulai buka toko di Akay Nusantara</h1>
           <p className="mt-3 max-w-2xl text-sm text-gray-600">
             Hai {account.name.split(" ")[0]}, akun Anda saat ini berada pada status <strong>{statusLabel}</strong>.
@@ -61,7 +61,7 @@ export default async function SellerOnboarding() {
           </p>
           <div className="mt-6 flex flex-col gap-3 text-sm text-gray-600 md:flex-row md:items-center md:justify-between">
             <div className="flex items-center gap-2">
-              <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-[#f53d2d]/10 text-base font-semibold text-[#f53d2d]">
+              <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-base font-semibold text-primary">
                 {account.sellerOnboardingStatus === "IN_PROGRESS" ? "⏳" : "🛍️"}
               </span>
               <span>
@@ -70,7 +70,7 @@ export default async function SellerOnboarding() {
             </div>
             <Link
               href="/"
-              className="inline-flex items-center justify-center rounded-full bg-[#f53d2d] px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-[#f53d2d]/30 transition hover:bg-[#d63b22]"
+              className="inline-flex items-center justify-center rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-lg shadow-[0_12px_30px_rgba(75,83,32,0.3)] transition hover:bg-primary-strong"
             >
               Belanja sebagai pembeli
             </Link>
@@ -87,7 +87,7 @@ export default async function SellerOnboarding() {
         <ol className="mt-6 space-y-4">
           {steps.map((step, index) => (
             <li key={step.title} className="flex gap-4 rounded-2xl border border-gray-100 bg-gray-50/80 p-5">
-              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-white text-lg font-semibold text-[#f53d2d] shadow">
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-white text-lg font-semibold text-primary shadow">
                 {index + 1}
               </div>
               <div className="space-y-1">
@@ -99,7 +99,7 @@ export default async function SellerOnboarding() {
         </ol>
       </section>
 
-      <section className="rounded-3xl border border-dashed border-[#f53d2d]/40 bg-[#fef2f2] p-8 text-sm text-[#b42318]">
+      <section className="rounded-3xl border border-dashed border-primary/40 bg-[hsl(var(--primary-soft))] p-8 text-sm text-primary">
         <p>
           Setelah seluruh tahap selesai, hubungi tim kami melalui email <a className="underline" href="mailto:support@akay.id">support@akay.id</a> dengan melampirkan bukti data toko untuk proses aktivasi.
         </p>

--- a/app/seller/orders/page.tsx
+++ b/app/seller/orders/page.tsx
@@ -111,7 +111,7 @@ export default async function SellerOrders() {
                           <option value="SHIPPED">SHIPPED</option>
                           <option value="DELIVERED">DELIVERED</option>
                         </select>
-                        <button className="w-full rounded-xl bg-[#f53d2d] px-3 py-2 text-sm font-semibold text-white shadow-sm">
+                        <button className="w-full rounded-xl bg-primary px-3 py-2 text-sm font-semibold text-primary-foreground shadow-sm">
                           Simpan Status
                         </button>
                       </form>
@@ -122,7 +122,7 @@ export default async function SellerOrders() {
                   <span className="font-semibold text-gray-900">
                     Subtotal Anda: Rp {new Intl.NumberFormat("id-ID").format(subtotal)}
                   </span>
-                  <Link className="text-[#f53d2d] underline" href={`/order/${order.orderCode}`}>
+                  <Link className="text-primary underline" href={`/order/${order.orderCode}`}>
                     Lihat detail
                   </Link>
                 </footer>

--- a/app/seller/products/page.tsx
+++ b/app/seller/products/page.tsx
@@ -163,7 +163,7 @@ export default async function SellerProducts({
           <p className="text-xs text-gray-500 md:col-span-2">
             Tambahkan setiap kelompok varian di baris baru dengan format <span className="font-medium">Nama: opsi1, opsi2</span>.
           </p>
-          <button className="rounded-full bg-[#f53d2d] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[#d73224] md:col-span-2">
+          <button className="rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-sm transition hover:bg-primary-strong md:col-span-2">
             Simpan Produk
           </button>
         </form>
@@ -236,7 +236,7 @@ export default async function SellerProducts({
                   </Link>
                   <form method="POST" action={`/api/seller/products/update/${product.id}`}>
                     <input type="hidden" name="toggle" value="1" />
-                    <button className="w-full rounded-full bg-[#f53d2d] px-4 py-2 text-sm font-semibold text-white shadow-sm">
+                    <button className="w-full rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-sm">
                       {product.isActive ? "Nonaktifkan" : "Aktifkan"}
                     </button>
                   </form>

--- a/app/seller/register/page.tsx
+++ b/app/seller/register/page.tsx
@@ -11,12 +11,12 @@ export default function SellerRegister({
 
   return (
     <div className="mx-auto w-full max-w-5xl">
-      <div className="relative overflow-hidden rounded-[36px] bg-gradient-to-br from-[#f53d2d] via-[#ff7243] to-[#ff9061] p-1 shadow-2xl">
+      <div className="relative overflow-hidden rounded-[36px] bg-gradient-to-br from-primary via-primary-bright to-primary-soft p-1 shadow-2xl">
         <div className="relative flex flex-col gap-10 rounded-[34px] bg-white/90 p-6 lg:flex-row lg:p-10">
-          <div className="relative hidden min-h-[420px] flex-1 flex-col justify-between overflow-hidden rounded-[28px] bg-gradient-to-br from-[#f53d2d] to-[#ff6636] p-10 text-white lg:flex">
+          <div className="relative hidden min-h-[420px] flex-1 flex-col justify-between overflow-hidden rounded-[28px] bg-gradient-to-br from-primary to-primary-bright p-10 text-white lg:flex">
             <div className="space-y-6">
               <div className="flex items-center gap-4">
-                <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-white text-3xl font-bold text-[#f53d2d]">
+                <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-white text-3xl font-bold text-primary">
                   A
                 </div>
                 <div>
@@ -51,7 +51,7 @@ export default function SellerRegister({
               <span>Daftar</span>
               <a
                 href="mailto:support@akay.id"
-                className="font-medium text-[#f53d2d] hover:text-[#d63b22]"
+                className="font-medium text-primary hover:text-primary-strong"
               >
                 Butuh bantuan?
               </a>
@@ -100,7 +100,7 @@ export default function SellerRegister({
                       name="name"
                       required
                       placeholder="Masukkan nama Anda"
-                      className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/40"
+                      className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
                     />
                   </div>
                   <div className="space-y-1">
@@ -113,7 +113,7 @@ export default function SellerRegister({
                       name="email"
                       required
                       placeholder="contoh@email.com atau 0812xxxx"
-                      className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/40"
+                      className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
                     />
                   </div>
                   <div className="space-y-1">
@@ -126,7 +126,7 @@ export default function SellerRegister({
                       name="password"
                       required
                       placeholder="Minimal 8 karakter"
-                      className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/40"
+                      className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
                     />
                   </div>
                   <div className="space-y-1">
@@ -139,11 +139,11 @@ export default function SellerRegister({
                       name="confirmPassword"
                       required
                       placeholder="Ulangi password"
-                      className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/40"
+                      className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
                     />
                   </div>
                   <button
-                    className="w-full rounded-xl bg-[#f53d2d] px-4 py-3 text-sm font-semibold uppercase tracking-wide text-white shadow-lg shadow-[#f53d2d]/30 transition hover:bg-[#e13a24] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/50"
+                    className="w-full rounded-xl bg-primary px-4 py-3 text-sm font-semibold uppercase tracking-wide text-primary-foreground shadow-lg shadow-[0_12px_30px_rgba(75,83,32,0.3)] transition hover:bg-primary-strong focus:outline-none focus:ring-2 focus:ring-primary/50"
                   >
                     Daftar sekarang
                   </button>
@@ -158,13 +158,13 @@ export default function SellerRegister({
                 <div className="grid gap-3 text-sm">
                   <button
                     type="button"
-                    className="flex items-center justify-center gap-3 rounded-xl border border-gray-200 bg-white px-4 py-3 font-medium text-gray-700 transition hover:border-[#f53d2d]/40 hover:text-[#f53d2d]"
+                    className="flex items-center justify-center gap-3 rounded-xl border border-gray-200 bg-white px-4 py-3 font-medium text-gray-700 transition hover:border-primary/40 hover:text-primary"
                   >
                     Daftar dengan Facebook
                   </button>
                   <a
                     href="/api/auth/google"
-                    className="flex items-center justify-center gap-3 rounded-xl border border-gray-200 bg-white px-4 py-3 text-center font-medium text-gray-700 transition hover:border-[#f53d2d]/40 hover:text-[#f53d2d]"
+                    className="flex items-center justify-center gap-3 rounded-xl border border-gray-200 bg-white px-4 py-3 text-center font-medium text-gray-700 transition hover:border-primary/40 hover:text-primary"
                   >
                     Daftar dengan Google
                   </a>
@@ -172,7 +172,7 @@ export default function SellerRegister({
 
                 <div className="mt-6 text-center text-sm text-gray-500">
                   Sudah punya akun?{" "}
-                  <Link href="/seller/login" className="font-semibold text-[#f53d2d] hover:text-[#d63b22]">
+                  <Link href="/seller/login" className="font-semibold text-primary hover:text-primary-strong">
                     Log in sekarang
                   </Link>
                 </div>

--- a/app/seller/settings/page.tsx
+++ b/app/seller/settings/page.tsx
@@ -113,7 +113,7 @@ export default async function SellerSettings({ searchParams }: SettingsPageProps
               minLength={3}
               defaultValue={account.name}
               placeholder="Contoh: Akay Nusantara"
-              className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/40"
+              className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
             />
             <p className="text-xs text-gray-500">Nama toko akan ditampilkan kepada pembeli di halaman etalase Anda.</p>
           </div>
@@ -130,7 +130,7 @@ export default async function SellerSettings({ searchParams }: SettingsPageProps
           </div>
 
           <div className="flex flex-col gap-2 md:flex-row md:items-center">
-            <button className="rounded-full bg-[#f53d2d] px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[#d73224]" type="submit">
+            <button className="rounded-full bg-primary px-5 py-2 text-sm font-semibold text-primary-foreground shadow-sm transition hover:bg-primary-strong" type="submit">
               Simpan perubahan
             </button>
             <span className="text-xs text-gray-500 md:ml-3">Perubahan dapat memerlukan waktu beberapa menit untuk muncul di hasil pencarian.</span>
@@ -168,7 +168,7 @@ export default async function SellerSettings({ searchParams }: SettingsPageProps
               defaultValue={account.storeAddressLine ?? ""}
               placeholder="Contoh: Jl. Melati No. 10, Blok B"
               rows={3}
-              className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/40"
+              className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
             />
           </div>
 
@@ -184,7 +184,7 @@ export default async function SellerSettings({ searchParams }: SettingsPageProps
                 required
                 defaultValue={account.storeProvince ?? ""}
                 placeholder="Contoh: Jawa Barat"
-                className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/40"
+                className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
               />
             </div>
             <div className="space-y-1">
@@ -198,7 +198,7 @@ export default async function SellerSettings({ searchParams }: SettingsPageProps
                 required
                 defaultValue={account.storeCity ?? ""}
                 placeholder="Contoh: Bandung"
-                className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/40"
+                className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
               />
             </div>
           </div>
@@ -214,7 +214,7 @@ export default async function SellerSettings({ searchParams }: SettingsPageProps
                 type="text"
                 defaultValue={account.storeDistrict ?? ""}
                 placeholder="Contoh: Sukajadi"
-                className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/40"
+                className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
               />
             </div>
             <div className="space-y-1">
@@ -229,7 +229,7 @@ export default async function SellerSettings({ searchParams }: SettingsPageProps
                 pattern="[0-9]*"
                 defaultValue={account.storePostalCode ?? ""}
                 placeholder="Contoh: 40162"
-                className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/40"
+                className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
               />
             </div>
           </div>
@@ -244,7 +244,7 @@ export default async function SellerSettings({ searchParams }: SettingsPageProps
               type="text"
               defaultValue={account.storeOriginCityId ?? ""}
               placeholder="Opsional, isi jika Anda tahu kode kota RajaOngkir"
-              className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/40"
+              className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
             />
             <p className="text-xs text-gray-500">
               Mengisi kode kota RajaOngkir membantu mempercepat pencocokan kota asal secara otomatis.
@@ -252,7 +252,7 @@ export default async function SellerSettings({ searchParams }: SettingsPageProps
           </div>
 
           <div className="flex flex-col gap-2 md:flex-row md:items-center">
-            <button className="rounded-full bg-[#f53d2d] px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[#d73224]" type="submit">
+            <button className="rounded-full bg-primary px-5 py-2 text-sm font-semibold text-primary-foreground shadow-sm transition hover:bg-primary-strong" type="submit">
               Simpan alamat
             </button>
             <span className="text-xs text-gray-500 md:ml-3">Pastikan kota sesuai dengan data RajaOngkir agar ongkir otomatis berhasil.</span>

--- a/app/voucher/page.tsx
+++ b/app/voucher/page.tsx
@@ -74,12 +74,12 @@ export default async function VoucherPage() {
               return (
                 <article
                   key={entry.id}
-                  className="flex flex-col justify-between rounded-3xl border border-[#fcd3c7] bg-gradient-to-br from-white via-white to-[#fff4f1] p-5 shadow-sm"
+                  className="flex flex-col justify-between rounded-3xl border border-primary/20 bg-gradient-to-br from-white via-white to-[hsl(var(--primary-soft))] p-5 shadow-sm"
                 >
                   <div className="space-y-2">
-                    <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-[#f53d2d]">
+                    <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-primary">
                       <span>Kode {voucher.code}</span>
-                      <span className="rounded-full bg-[#f53d2d]/10 px-3 py-1 text-[11px] text-[#f53d2d]">Tersimpan</span>
+                      <span className="rounded-full bg-primary/10 px-3 py-1 text-[11px] text-primary">Tersimpan</span>
                     </div>
                     <p className="text-lg font-semibold text-gray-900">{benefit}</p>
                     <p className="text-sm text-gray-600">Min. belanja Rp {formatIDR(voucher.minSpend)}</p>
@@ -137,7 +137,7 @@ export default async function VoucherPage() {
                         voucherId={voucher.id}
                         voucherCode={voucher.code}
                         size="sm"
-                        color={isClaimed ? "indigo" : "salmon"}
+                        color={isClaimed ? "indigo" : "primary"}
                         variant={isClaimed ? "outline" : "solid"}
                         className={isClaimed ? "w-full" : "w-full shadow"}
                       >

--- a/components/AddressRegionFields.tsx
+++ b/components/AddressRegionFields.tsx
@@ -26,7 +26,7 @@ type AddressRegionFieldsProps = {
 };
 
 const FIELD_CLASSNAME =
-  "w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-[#f53d2d] focus:outline-none focus:ring-2 focus:ring-[#f53d2d]/30";
+  "w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30";
 
 function normalize(value: string) {
   return value

--- a/components/ClaimVoucherButton.tsx
+++ b/components/ClaimVoucherButton.tsx
@@ -14,7 +14,7 @@ type ClaimVoucherButtonProps = {
   className?: string;
   size?: "sm" | "md";
   variant?: "solid" | "outline";
-  color?: "indigo" | "salmon";
+  color?: "indigo" | "primary";
 };
 
 export function ClaimVoucherButton({
@@ -24,7 +24,7 @@ export function ClaimVoucherButton({
   className,
   size = "md",
   variant = "solid",
-  color = "indigo",
+  color = "primary",
 }: ClaimVoucherButtonProps) {
   const router = useRouter();
   const [status, setStatus] = useState<"idle" | "loading" | "claimed" | "error">("idle");
@@ -36,14 +36,14 @@ export function ClaimVoucherButton({
   const sizeClass = size === "sm" ? "px-3 py-2 text-xs" : "px-4 py-2.5 text-sm";
   const baseClass = (() => {
     if (variant === "outline") {
-      if (color === "salmon") {
-        return "border border-[#fcd3c7] text-[#f53d2d] hover:border-[#f8b5a3] hover:text-[#d73224]";
+      if (color === "primary") {
+        return "border border-primary/30 text-primary hover:border-primary/50 hover:text-primary-strong";
       }
       return "border border-indigo-200 text-indigo-600 hover:border-indigo-300 hover:text-indigo-500";
     }
 
-    if (color === "salmon") {
-      return "bg-[#f53d2d] text-white hover:bg-[#d73224]";
+    if (color === "primary") {
+      return "bg-primary text-primary-foreground hover:bg-primary-strong";
     }
 
     return "bg-indigo-600 text-white hover:bg-indigo-500";
@@ -100,7 +100,8 @@ export function ClaimVoucherButton({
         disabled={isLoading || isClaimed}
         onClick={handleClaim}
         className={mergeClassNames(
-          "inline-flex items-center justify-center rounded-full font-semibold transition focus:outline-none focus:ring-2 focus:ring-indigo-500/40",
+          "inline-flex items-center justify-center rounded-full font-semibold transition focus:outline-none focus:ring-2",
+          color === "primary" ? "focus:ring-primary/40" : "focus:ring-indigo-500/40",
           sizeClass,
           baseClass,
           disabledClass,

--- a/components/MobileTabBar.tsx
+++ b/components/MobileTabBar.tsx
@@ -19,7 +19,7 @@ export function MobileTabBar() {
   }
 
   return (
-    <nav className="fixed inset-x-0 bottom-0 z-50 border-t border-gray-200 bg-white/95 shadow-[0_-2px_20px_rgba(15,23,42,0.08)] backdrop-blur md:hidden">
+    <nav className="fixed inset-x-0 bottom-0 z-50 border-t border-border bg-background/95 shadow-[0_-2px_20px_rgba(15,23,42,0.08)] backdrop-blur md:hidden">
       <div className="mx-auto flex max-w-6xl items-center justify-between px-2 py-2">
         {tabs.map((tab) => {
           const isActive = pathname === tab.href || (tab.href !== "/" && pathname.startsWith(tab.href));
@@ -28,7 +28,7 @@ export function MobileTabBar() {
               key={tab.href}
               href={tab.href}
               className={`flex flex-1 flex-col items-center gap-1 rounded-xl px-1 py-1 text-[11px] font-medium transition ${
-                isActive ? "text-[#f53d2d]" : "text-gray-500 hover:text-[#f53d2d]"
+                isActive ? "text-primary" : "text-gray-500 hover:text-primary"
               }`}
             >
               <span className="text-lg">{tab.icon}</span>

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -81,7 +81,7 @@ export function ProductCard({
             <div className="flex h-full w-full items-center justify-center text-3xl">🛍️</div>
           )}
           {derivedDiscountPercent ? (
-            <span className="absolute right-3 top-3 rounded-md bg-[#f53d2d] px-2 py-1 text-xs font-semibold text-white shadow">
+            <span className="absolute right-3 top-3 rounded-md bg-primary px-2 py-1 text-xs font-semibold text-primary-foreground shadow">
               -{derivedDiscountPercent}%
             </span>
           ) : null}
@@ -91,7 +91,7 @@ export function ProductCard({
         <div className="flex items-start gap-2">
           <Link
             href={href}
-            className="flex-1 text-sm font-semibold text-gray-900 line-clamp-2 transition-colors duration-200 group-hover:text-[#f53d2d]"
+            className="flex-1 text-sm font-semibold text-gray-900 line-clamp-2 transition-colors duration-200 group-hover:text-primary"
           >
             {title}
           </Link>
@@ -111,7 +111,7 @@ export function ProductCard({
           ) : null}
         </div>
         <div className="mt-1 flex items-baseline justify-between">
-          <div className="text-lg font-bold text-[#f53d2d]">Rp {formatIDR(salePrice)}</div>
+          <div className="text-lg font-bold text-primary">Rp {formatIDR(salePrice)}</div>
           {typeof soldCount === "number" ? (
             <div className="text-[11px] font-medium text-gray-500">{formatSoldCount(soldCount)} Terjual</div>
           ) : null}

--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -93,7 +93,7 @@ export function SiteHeader({ user }: SiteHeaderProps) {
   }, []);
 
   return (
-    <header className="bg-gradient-to-r from-[#f53d2d] via-[#f63] to-[#ff6f3c] text-white shadow">
+    <header className="bg-gradient-to-r from-primary via-primary-bright to-primary-soft text-primary-foreground shadow">
       <div className="hidden border-b border-white/20 md:block">
         <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-2 text-xs">
           <div className="flex items-center gap-4">
@@ -231,7 +231,7 @@ export function SiteHeader({ user }: SiteHeaderProps) {
           />
           <button
             type="submit"
-            className="bg-[#f53d2d] px-4 text-sm font-semibold text-white transition hover:bg-[#d73224]"
+            className="bg-primary px-4 text-sm font-semibold text-primary-foreground transition hover:bg-primary-strong"
           >
             Cari
           </button>
@@ -241,7 +241,7 @@ export function SiteHeader({ user }: SiteHeaderProps) {
             <span aria-hidden>🛒</span>
             Keranjang
             {cartCount > 0 ? (
-              <span className="absolute -right-4 -top-2 inline-flex h-5 min-w-[20px] items-center justify-center rounded-full bg-white px-1 text-xs font-semibold text-[#f53d2d]">
+              <span className="absolute -right-4 -top-2 inline-flex h-5 min-w-[20px] items-center justify-center rounded-full bg-white px-1 text-xs font-semibold text-primary">
                 {cartCount}
               </span>
             ) : null}
@@ -261,7 +261,7 @@ export function SiteHeader({ user }: SiteHeaderProps) {
               <Link href="/cart" aria-label="Keranjang" className="relative transition hover:scale-105">
                 🛒
                 {cartCount > 0 ? (
-                  <span className="absolute -right-2 -top-2 inline-flex h-4 min-w-[18px] items-center justify-center rounded-full bg-white text-[10px] font-semibold text-[#f53d2d]">
+                  <span className="absolute -right-2 -top-2 inline-flex h-4 min-w-[18px] items-center justify-center rounded-full bg-white text-[10px] font-semibold text-primary">
                     {cartCount}
                   </span>
                 ) : null}
@@ -278,14 +278,14 @@ export function SiteHeader({ user }: SiteHeaderProps) {
             </div>
           </div>
           <form className="mt-3 flex items-center gap-2 rounded-full bg-white/95 px-4 py-2 text-sm text-gray-700 shadow-inner" action="/search" method="GET">
-            <span aria-hidden className="text-lg text-[#f53d2d]">🔍</span>
+            <span aria-hidden className="text-lg text-primary">🔍</span>
             <input
               name="q"
               type="search"
               placeholder="Cari produk, toko, dan voucher"
               className="flex-1 bg-transparent outline-none"
             />
-            <button type="submit" className="rounded-full bg-[#f53d2d] px-3 py-1 text-xs font-semibold text-white">
+            <button type="submit" className="rounded-full bg-primary px-3 py-1 text-xs font-semibold text-primary-foreground">
               Cari
             </button>
           </form>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,9 +1,30 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ["./app/**/*.{ts,tsx}","./components/**/*.{ts,tsx}"],
+  darkMode: "class",
+  content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
   theme: {
     extend: {
-      colors: { army: "#4B5320" }
+      colors: {
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        border: "hsl(var(--border))",
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+          soft: "hsl(var(--primary-soft))",
+          bright: "hsl(var(--primary-bright))",
+          strong: "hsl(var(--primary-strong))",
+          ring: "hsl(var(--primary-ring))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- introduce CSS variable color palette with light/dark variants and expose them through Tailwind tokens
- replace the old orange brand styling with the new army green primary across headers, CTAs, vouchers, and navigation

## Testing
- npm run lint *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68e590eb400c8320837ccfaae1886beb