### PR TITLE
Standardize product dynamic route slug name

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Marketplace ala Shopee dengan **transfer manual + kode unik**, **COD**, **vouche
 - Buka `/api/seed` sekali setelah deploy.
 
 ## Route Ringkas
-- Public: `/`, `/product/[id]`, `/cart`, `/checkout`, `/order/[code]`, `/s/[slug]`
+- Public: `/`, `/product/[slug]`, `/cart`, `/checkout`, `/order/[code]`, `/s/[slug]`
 - Seller: `/seller/login`, `/seller/register`, `/seller/forgot-password`, `/seller/reset-password`, `/seller/dashboard`, `/seller/products`, `/seller/orders`, `/seller/warehouses`, `/seller/returns`
 - Admin: `/admin/orders`
 - API: lihat `/app/api/*`

--- a/app/product/[slug]/page.tsx
+++ b/app/product/[slug]/page.tsx
@@ -168,12 +168,12 @@ function IconShoppingCart({ className }: IconProps) {
   );
 }
 
-export default async function ProductPage({ params }: { params: { id: string } }) {
+export default async function ProductPage({ params }: { params: { slug: string } }) {
   const sessionPromise = getSession();
   const now = new Date();
 
   const product = await prisma.product.findUnique({
-    where: { id: params.id },
+    where: { id: params.slug },
     include: {
       seller: true,
       warehouse: true,


### PR DESCRIPTION
## Summary
- rename the product detail route folder from `[id]` to `[slug]` so Next.js no longer sees conflicting dynamic parameter names
- update the product page logic to reference `params.slug` after the rename and adjust the README route overview accordingly

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e59a575f148320a22a5d12cdfdac52