### PR TITLE
Reposition product card mall badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Marketplace ala Shopee dengan **transfer manual + kode unik**, **COD**, **vouche
 - Buka `/api/seed` sekali setelah deploy.
 
 ## Route Ringkas
-- Public: `/`, `/product/[id]`, `/cart`, `/checkout`, `/order/[code]`, `/s/[slug]`
+- Public: `/`, `/product/[slug]`, `/cart`, `/checkout`, `/order/[code]`, `/s/[slug]`
 - Seller: `/seller/login`, `/seller/register`, `/seller/forgot-password`, `/seller/reset-password`, `/seller/dashboard`, `/seller/products`, `/seller/orders`, `/seller/warehouses`, `/seller/returns`
 - Admin: `/admin/orders`
 - API: lihat `/app/api/*`

--- a/app/product/[slug]/page.tsx
+++ b/app/product/[slug]/page.tsx
@@ -168,12 +168,12 @@ function IconShoppingCart({ className }: IconProps) {
   );
 }
 
-export default async function ProductPage({ params }: { params: { id: string } }) {
+export default async function ProductPage({ params }: { params: { slug: string } }) {
   const sessionPromise = getSession();
   const now = new Date();
 
   const product = await prisma.product.findUnique({
-    where: { id: params.id },
+    where: { id: params.slug },
     include: {
       seller: true,
       warehouse: true,

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -89,15 +89,9 @@ export function ProductCard({
       </Link>
       <div className="flex flex-1 flex-col gap-2 px-4 py-4">
         <div className="flex items-start gap-2">
-          <Link
-            href={href}
-            className="flex-1 text-sm font-semibold text-gray-900 line-clamp-2 transition-colors duration-200 group-hover:text-[#f53d2d]"
-          >
-            {title}
-          </Link>
           {showBadge ? (
             <span
-              className={`inline-flex items-center rounded-sm text-[10px] font-semibold uppercase tracking-wide ${
+              className={`inline-flex shrink-0 items-center rounded-sm text-[10px] font-semibold uppercase tracking-wide ${
                 badge.imageSrc ? "" : "px-2 py-0.5"
               } ${badge.className}`}
             >
@@ -109,6 +103,12 @@ export function ProductCard({
               )}
             </span>
           ) : null}
+          <Link
+            href={href}
+            className="flex-1 text-sm font-semibold text-gray-900 line-clamp-2 transition-colors duration-200 group-hover:text-[#f53d2d]"
+          >
+            {title}
+          </Link>
         </div>
         <div className="mt-1 flex items-baseline justify-between">
           <div className="text-lg font-bold text-[#f53d2d]">Rp {formatIDR(salePrice)}</div>


### PR DESCRIPTION
## Summary
- move the store badge markup before the product title so the "Mall" badge renders on the left side of each card
- prevent the badge from shrinking so it stays aligned with the product title when present

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e59a575f148320a22a5d12cdfdac52