### PR TITLE
Point seller Google OAuth buttons at app route

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Marketplace ala Shopee dengan **transfer manual + kode unik**, **COD**, **vouche
 - `DATABASE_URL`
 - `IRON_SESSION_PASSWORD`
 - `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM` (untuk mengirim OTP reset password). Saat variabel ini tidak diisi, email akan dicetak ke log saja.
-- `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI` (opsional — default ke `/api/auth/google/callback` sesuai origin) untuk login Google.
+- `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI` (opsional — default mengikuti origin & jalur yang dipakai, baik `/api/auth/google/callback` maupun `/auth/google/callback`) untuk login Google.
 - `REDIS_URL` untuk presence, typing indicator, dan antrian notifikasi chat.
 - `RAJAONGKIR_API_KEY` (wajib) dan `RAJAONGKIR_API_BASE_URL` (opsional, default `https://api.rajaongkir.com/starter/`) untuk sinkronisasi daftar provinsi/kota/kecamatan.
 - `RAJAONGKIR_DEFAULT_ORIGIN_CITY_ID` (disarankan) atau `RAJAONGKIR_DEFAULT_ORIGIN_CITY` sebagai fallback kota asal ketika gudang tidak memiliki kota tersimpan. Nilai ini dipakai saat menghitung ongkir melalui RajaOngkir.

--- a/app/(auth)/seller/login/page.tsx
+++ b/app/(auth)/seller/login/page.tsx
@@ -103,7 +103,7 @@ export default async function SellerLogin({
             Masuk dengan Facebook
           </button>
           <a
-            href="/api/auth/google"
+            href="/auth/google"
             className="flex w-full items-center justify-center gap-3 rounded-2xl bg-white/70 px-4 py-3 text-center font-medium text-sky-700 transition hover:bg-white/90"
           >
             Masuk dengan Google

--- a/app/(auth)/seller/register/page.tsx
+++ b/app/(auth)/seller/register/page.tsx
@@ -107,7 +107,7 @@ export default function SellerRegister({
                 Daftar dengan Facebook
               </button>
               <a
-                href="/api/auth/google"
+                href="/auth/google"
                 className="flex w-full items-center justify-center gap-3 rounded-2xl bg-white/70 px-4 py-3 text-center font-medium text-sky-700 transition hover:bg-white/90"
               >
                 Daftar dengan Google

--- a/app/api/auth/google/callback/shared.ts
+++ b/app/api/auth/google/callback/shared.ts
@@ -7,7 +7,8 @@ import { prisma } from "@/lib/prisma";
 import { sessionOptions, type SessionUser } from "@/lib/session";
 import { slugify } from "@/lib/utils";
 
-const STATE_COOKIE = "google_oauth_state";
+import { STATE_COOKIE } from "../shared";
+
 const TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
 const USERINFO_ENDPOINT = "https://openidconnect.googleapis.com/v1/userinfo";
 
@@ -58,7 +59,7 @@ export async function handleGoogleCallback(req: NextRequest): Promise<NextRespon
   const clientId = process.env.GOOGLE_CLIENT_ID;
   const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
   const redirectUri =
-    process.env.GOOGLE_REDIRECT_URI || `${url.origin}/api/auth/google/callback`;
+    process.env.GOOGLE_REDIRECT_URI?.trim() || `${url.origin}${url.pathname}`;
 
   if (!clientId || !clientSecret) {
     return clearStateCookie(

--- a/app/api/auth/google/route.ts
+++ b/app/api/auth/google/route.ts
@@ -1,36 +1,7 @@
-import { randomUUID } from "node:crypto";
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 
-const GOOGLE_AUTH_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth";
-const STATE_COOKIE = "google_oauth_state";
+import { createGoogleAuthRedirect } from "./shared";
 
 export async function GET(req: NextRequest) {
-  const clientId = process.env.GOOGLE_CLIENT_ID;
-  const redirectUri =
-    process.env.GOOGLE_REDIRECT_URI || `${req.nextUrl.origin}/api/auth/google/callback`;
-
-  if (!clientId) {
-    return NextResponse.json({ error: "Google OAuth is not configured" }, { status: 500 });
-  }
-
-  const state = randomUUID();
-  const target = new URL(GOOGLE_AUTH_ENDPOINT);
-
-  target.searchParams.set("client_id", clientId);
-  target.searchParams.set("redirect_uri", redirectUri);
-  target.searchParams.set("response_type", "code");
-  target.searchParams.set("scope", "openid email profile");
-  target.searchParams.set("state", state);
-  target.searchParams.set("prompt", "select_account");
-
-  const response = NextResponse.redirect(target);
-  response.cookies.set(STATE_COOKIE, state, {
-    httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
-    sameSite: "lax",
-    maxAge: 60 * 10,
-    path: "/",
-  });
-
-  return response;
+  return createGoogleAuthRedirect(req);
 }

--- a/app/api/auth/google/shared.ts
+++ b/app/api/auth/google/shared.ts
@@ -1,0 +1,70 @@
+import { randomUUID } from "node:crypto";
+import { NextRequest, NextResponse } from "next/server";
+
+export const STATE_COOKIE = "google_oauth_state";
+const GOOGLE_AUTH_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth";
+
+type RedirectOptions = {
+  callbackPath?: string;
+};
+
+function buildCallbackPath(req: NextRequest, override?: string) {
+  if (override) {
+    return override;
+  }
+
+  const currentPath = req.nextUrl.pathname.replace(/\/$/, "");
+  const basePath = currentPath.length > 0 ? currentPath : "";
+  return `${basePath}/callback`;
+}
+
+export function buildGoogleRedirectUri(
+  req: NextRequest,
+  options: RedirectOptions = {},
+) {
+  const configured = process.env.GOOGLE_REDIRECT_URI?.trim();
+  if (configured) {
+    return configured;
+  }
+
+  const callbackUrl = req.nextUrl.clone();
+  callbackUrl.pathname = buildCallbackPath(req, options.callbackPath);
+  callbackUrl.search = "";
+  callbackUrl.hash = "";
+  return callbackUrl.toString();
+}
+
+export function createGoogleAuthRedirect(
+  req: NextRequest,
+  options: RedirectOptions = {},
+) {
+  const clientId = process.env.GOOGLE_CLIENT_ID;
+  if (!clientId) {
+    return NextResponse.json(
+      { error: "Google OAuth is not configured" },
+      { status: 500 },
+    );
+  }
+
+  const redirectUri = buildGoogleRedirectUri(req, options);
+  const state = randomUUID();
+  const target = new URL(GOOGLE_AUTH_ENDPOINT);
+
+  target.searchParams.set("client_id", clientId);
+  target.searchParams.set("redirect_uri", redirectUri);
+  target.searchParams.set("response_type", "code");
+  target.searchParams.set("scope", "openid email profile");
+  target.searchParams.set("state", state);
+  target.searchParams.set("prompt", "select_account");
+
+  const response = NextResponse.redirect(target);
+  response.cookies.set(STATE_COOKIE, state, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: 60 * 10,
+    path: "/",
+  });
+
+  return response;
+}

--- a/app/auth/google/route.ts
+++ b/app/auth/google/route.ts
@@ -1,0 +1,7 @@
+import { NextRequest } from "next/server";
+
+import { createGoogleAuthRedirect } from "@/app/api/auth/google/shared";
+
+export async function GET(req: NextRequest) {
+  return createGoogleAuthRedirect(req, { callbackPath: "/auth/google/callback" });
+}


### PR DESCRIPTION
## Summary
- update the seller login and registration Google buttons to hit the `/auth/google` entrypoint so callbacks resolve to the matching callback route

## Testing
- `npm run build` *(fails to reach the remote database, but the Next.js build completes successfully)*

------
https://chatgpt.com/codex/tasks/task_e_68e6044ae5ac8320a4948d4efee216eb