### PR TITLE
feat: record variant selections as order notes

### DIFF
--- a/app/(site)/checkout/page.tsx
+++ b/app/(site)/checkout/page.tsx
@@ -1,7 +1,15 @@
 "use client";
 import { useEffect, useState } from "react";
 
-type CartItem = { productId: string; title: string; price: number; qty: number; sellerId: string };
+type CartItem = {
+  productId: string;
+  title: string;
+  price: number;
+  qty: number;
+  sellerId: string;
+  note?: string | null;
+  variants?: Record<string, string>;
+};
 
 type CheckoutAccountData = {
   profile: {
@@ -302,7 +310,16 @@ export default function CheckoutPage() {
     }
 
     const fd = new FormData(e.currentTarget);
-    fd.append('items', JSON.stringify(items));
+    fd.append(
+      'items',
+      JSON.stringify(
+        items.map((item) => ({
+          productId: item.productId,
+          qty: item.qty,
+          note: item.note ?? undefined,
+        })),
+      ),
+    );
     fd.append('courier', courier);
 
     setSubmitting(true);
@@ -519,12 +536,24 @@ export default function CheckoutPage() {
       <div className="bg-white border rounded p-4">
         <h2 className="font-semibold mb-2">Ringkasan</h2>
         <ul className="text-sm">
-          {items.map(it => (
-            <li key={it.productId} className="flex justify-between border-b py-1">
-              <span>{it.title} × {it.qty}</span>
-              <span>Rp {new Intl.NumberFormat('id-ID').format(it.price*it.qty)}</span>
-            </li>
-          ))}
+          {items.map((it) => {
+            const key = `${it.productId}::${it.note ?? ''}`;
+            return (
+              <li key={key} className="border-b py-1">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <span className="block font-medium text-gray-800">
+                      {it.title} × {it.qty}
+                    </span>
+                    {it.note ? (
+                      <span className="mt-0.5 block text-xs text-gray-500">Catatan: {it.note}</span>
+                    ) : null}
+                  </div>
+                  <span>Rp {new Intl.NumberFormat('id-ID').format(it.price * it.qty)}</span>
+                </div>
+              </li>
+            );
+          })}
         </ul>
         <div className="space-y-2 text-sm mt-4">
           <div className="flex items-center justify-between">

--- a/app/(site)/order/[code]/page.tsx
+++ b/app/(site)/order/[code]/page.tsx
@@ -158,6 +158,9 @@ export default async function OrderDetailPage({ params }: { params: { code: stri
                     )}
                   </h3>
                   <p className="text-xs text-gray-500">Qty: {item.qty} • Status item: {item.status}</p>
+                  {item.note ? (
+                    <p className="text-xs text-gray-500">Catatan pesanan: {item.note}</p>
+                  ) : null}
                   {seller ? (
                     <p className="text-xs text-gray-500">
                       Toko:

--- a/app/(site)/order/[code]/page.tsx
+++ b/app/(site)/order/[code]/page.tsx
@@ -131,6 +131,7 @@ export default async function OrderDetailPage({ params }: { params: { code: stri
             </p>
           ) : null}
           {order.items.map((item) => {
+            const itemNote = (item as { note?: string | null }).note;
             const product = item.product;
             const seller = product?.seller ?? null;
             return (
@@ -158,8 +159,8 @@ export default async function OrderDetailPage({ params }: { params: { code: stri
                     )}
                   </h3>
                   <p className="text-xs text-gray-500">Qty: {item.qty} • Status item: {item.status}</p>
-                  {item.note ? (
-                    <p className="text-xs text-gray-500">Catatan pesanan: {item.note}</p>
+                  {itemNote ? (
+                    <p className="text-xs text-gray-500">Catatan pesanan: {itemNote}</p>
                   ) : null}
                   {seller ? (
                     <p className="text-xs text-gray-500">

--- a/app/(site)/orders/page.tsx
+++ b/app/(site)/orders/page.tsx
@@ -442,6 +442,9 @@ export default function BuyerOrdersPage() {
                             )}
                           </p>
                           <p className="text-xs text-gray-500">Qty: {item.qty}</p>
+                          {item.note ? (
+                            <p className="text-xs text-gray-500">Catatan pesanan: {item.note}</p>
+                          ) : null}
                           <p className="text-xs text-gray-500">Status item: {item.status}</p>
                           {seller ? (
                             <p className="text-xs text-gray-500">

--- a/app/(site)/orders/page.tsx
+++ b/app/(site)/orders/page.tsx
@@ -34,6 +34,7 @@ type BuyerOrder = {
     price: number;
     status: "PENDING" | "PACKED" | "SHIPPED" | "DELIVERED" | string;
     productId: string;
+    note: string | null;
     product: null | {
       id: string;
       slug: string;

--- a/app/(site)/product/[slug]/page.tsx
+++ b/app/(site)/product/[slug]/page.tsx
@@ -2,8 +2,7 @@ import Link from "next/link";
 import { prisma } from "@/lib/prisma";
 import { formatIDR } from "@/lib/utils";
 import { getCategoryDataset } from "@/lib/categories";
-import { VariantSelector } from "@/components/VariantSelector";
-import { AddToCartForm } from "@/components/AddToCartForm";
+import { ProductPurchaseOptions } from "@/components/ProductPurchaseOptions";
 import { VariantGroup } from "@/types/product";
 import {
   getPrimaryProductImageSrc,
@@ -564,20 +563,9 @@ export default async function ProductPage({ params }: { params: { slug: string }
                     <span>C.O.D &amp; Transfer Bank</span>
                   </div>
                 </div>
-
-                <div className="rounded-xl border border-gray-200 bg-white p-4">
-                  <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-500">Varian</h2>
-                  <VariantSelector groups={displayVariantGroups} />
-                  {variantGroups.length === 0 && (
-                    <p className="mt-3 text-xs text-gray-500">
-                      Penjual belum menambahkan detail varian, produk tersedia dalam 1 pilihan standar.
-                    </p>
-                  )}
-                </div>
-              </div>
-
-              <div className="hidden lg:block">
-                <AddToCartForm
+                <ProductPurchaseOptions
+                  variantGroups={displayVariantGroups}
+                  showSingleVariantNotice={variantGroups.length === 0}
                   productId={product.id}
                   title={product.title}
                   price={salePrice}
@@ -587,16 +575,6 @@ export default async function ProductPage({ params }: { params: { slug: string }
                   isLoggedIn={Boolean(currentUserId)}
                 />
               </div>
-              <AddToCartForm
-                productId={product.id}
-                title={product.title}
-                price={salePrice}
-                sellerId={product.sellerId}
-                stock={product.stock}
-                imageUrl={primaryImage}
-                isLoggedIn={Boolean(currentUserId)}
-                variant="mobile"
-              />
             </div>
           </div>
 

--- a/app/(site)/seller/orders/page.tsx
+++ b/app/(site)/seller/orders/page.tsx
@@ -81,45 +81,48 @@ export default async function SellerOrders() {
                   </div>
                 </header>
                 <div className="space-y-3">
-                  {order.items.map((item) => (
-                    <div key={item.id} className="rounded-2xl border border-gray-100 bg-gray-50 p-3">
-                      <div className="flex items-start justify-between gap-3">
-                        <div>
-                          <p className="text-sm font-semibold text-gray-900">{item.product.title}</p>
-                          <p className="text-xs text-gray-500">
-                            Qty: {item.qty} • Rp {new Intl.NumberFormat("id-ID").format(item.price)}
-                          </p>
-                          {item.note ? (
-                            <p className="text-xs text-gray-500">Catatan pesanan: {item.note}</p>
-                          ) : null}
+                  {order.items.map((item) => {
+                    const itemNote = (item as { note?: string | null }).note;
+                    return (
+                      <div key={item.id} className="rounded-2xl border border-gray-100 bg-gray-50 p-3">
+                        <div className="flex items-start justify-between gap-3">
+                          <div>
+                            <p className="text-sm font-semibold text-gray-900">{item.product.title}</p>
+                            <p className="text-xs text-gray-500">
+                              Qty: {item.qty} • Rp {new Intl.NumberFormat("id-ID").format(item.price)}
+                            </p>
+                            {itemNote ? (
+                              <p className="text-xs text-gray-500">Catatan pesanan: {itemNote}</p>
+                            ) : null}
+                          </div>
+                          <span className={`badge ${item.status === "PENDING" ? "badge-pending" : "badge-paid"}`}>
+                            {item.status}
+                          </span>
                         </div>
-                        <span className={`badge ${item.status === "PENDING" ? "badge-pending" : "badge-paid"}`}>
-                          {item.status}
-                        </span>
-                      </div>
-                      <form
-                        method="POST"
-                        action="/api/seller/item-status"
-                        className="mt-3 space-y-2"
-                      >
-                        <input type="hidden" name="orderCode" value={order.orderCode} />
-                        <input type="hidden" name="orderItemId" value={item.id} />
-                        <select
-                          name="status"
-                          defaultValue={item.status}
-                          className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm"
+                        <form
+                          method="POST"
+                          action="/api/seller/item-status"
+                          className="mt-3 space-y-2"
                         >
-                          <option value="PENDING">PENDING</option>
-                          <option value="PACKED">PACKED</option>
-                          <option value="SHIPPED">SHIPPED</option>
-                          <option value="DELIVERED">DELIVERED</option>
-                        </select>
-                        <button className="w-full rounded-xl bg-sky-500 px-3 py-2 text-sm font-semibold text-white shadow-sm">
-                          Simpan Status
-                        </button>
-                      </form>
-                    </div>
-                  ))}
+                          <input type="hidden" name="orderCode" value={order.orderCode} />
+                          <input type="hidden" name="orderItemId" value={item.id} />
+                          <select
+                            name="status"
+                            defaultValue={item.status}
+                            className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm"
+                          >
+                            <option value="PENDING">PENDING</option>
+                            <option value="PACKED">PACKED</option>
+                            <option value="SHIPPED">SHIPPED</option>
+                            <option value="DELIVERED">DELIVERED</option>
+                          </select>
+                          <button className="w-full rounded-xl bg-sky-500 px-3 py-2 text-sm font-semibold text-white shadow-sm">
+                            Simpan Status
+                          </button>
+                        </form>
+                      </div>
+                    );
+                  })}
                 </div>
                 <footer className="flex flex-wrap items-center justify-between gap-2 text-sm">
                   <span className="font-semibold text-gray-900">
@@ -162,36 +165,46 @@ export default async function SellerOrders() {
                     <td>Rp {new Intl.NumberFormat("id-ID").format(subtotal)}</td>
                     <td className="py-2 align-top">
                       <div className="space-y-3">
-                        {o.items.map((item) => (
-                          <div key={item.id} className="rounded border border-gray-100 bg-gray-50 px-3 py-2">
-                            <div className="flex justify-between gap-3">
-                              <div>
-                                <div className="font-medium">{item.product.title}</div>
-                                <div className="text-xs text-gray-500">
-                                  Qty: {item.qty} • Rp {new Intl.NumberFormat("id-ID").format(item.price)}
+                        {o.items.map((item) => {
+                          const itemNote = (item as { note?: string | null }).note;
+                          return (
+                            <div key={item.id} className="rounded border border-gray-100 bg-gray-50 px-3 py-2">
+                              <div className="flex justify-between gap-3">
+                                <div>
+                                  <div className="font-medium">{item.product.title}</div>
+                                  <div className="text-xs text-gray-500">
+                                    Qty: {item.qty} • Rp {new Intl.NumberFormat("id-ID").format(item.price)}
+                                  </div>
+                                  {itemNote ? (
+                                    <div className="text-xs text-gray-500">Catatan pesanan: {itemNote}</div>
+                                  ) : null}
                                 </div>
+                                <span className={`badge ${item.status === "PENDING" ? "badge-pending" : "badge-paid"}`}>
+                                  {item.status}
+                                </span>
                               </div>
-                              <span className={`badge ${item.status === "PENDING" ? "badge-pending" : "badge-paid"}`}>
-                                {item.status}
-                              </span>
+                              <form
+                                method="POST"
+                                action="/api/seller/item-status"
+                                className="mt-3 flex flex-col gap-2 md:flex-row md:items-center"
+                              >
+                                <input type="hidden" name="orderCode" value={o.orderCode} />
+                                <input type="hidden" name="orderItemId" value={item.id} />
+                                <select
+                                  name="status"
+                                  defaultValue={item.status}
+                                  className="border rounded px-3 py-2 text-sm"
+                                >
+                                  <option value="PENDING">PENDING</option>
+                                  <option value="PACKED">PACKED</option>
+                                  <option value="SHIPPED">SHIPPED</option>
+                                  <option value="DELIVERED">DELIVERED</option>
+                                </select>
+                                <button className="btn-primary text-sm">Update</button>
+                              </form>
                             </div>
-                            <form
-                              method="POST"
-                              action="/api/seller/item-status"
-                              className="mt-3 flex flex-col gap-2 md:flex-row md:items-center"
-                            >
-                              <input type="hidden" name="orderCode" value={o.orderCode} />
-                              <input type="hidden" name="orderItemId" value={item.id} />
-                              <select name="status" defaultValue={item.status} className="border rounded px-3 py-2 text-sm">
-                                <option value="PENDING">PENDING</option>
-                                <option value="PACKED">PACKED</option>
-                                <option value="SHIPPED">SHIPPED</option>
-                                <option value="DELIVERED">DELIVERED</option>
-                              </select>
-                              <button className="btn-primary text-sm">Update</button>
-                            </form>
-                          </div>
-                        ))}
+                          );
+                        })}
                       </div>
                     </td>
                     <td className="py-2 align-top">

--- a/app/(site)/seller/orders/page.tsx
+++ b/app/(site)/seller/orders/page.tsx
@@ -89,6 +89,9 @@ export default async function SellerOrders() {
                           <p className="text-xs text-gray-500">
                             Qty: {item.qty} • Rp {new Intl.NumberFormat("id-ID").format(item.price)}
                           </p>
+                          {item.note ? (
+                            <p className="text-xs text-gray-500">Catatan pesanan: {item.note}</p>
+                          ) : null}
                         </div>
                         <span className={`badge ${item.status === "PENDING" ? "badge-pending" : "badge-paid"}`}>
                           {item.status}

--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -25,7 +25,11 @@ export async function POST(req: NextRequest) {
   if (!courierKey || !courierMap[courierKey]) {
     courierKey = availableCourierKeys[0]!;
   }
-  const items = JSON.parse(String(form.get('items') || '[]')) as { productId: string; qty: number }[];
+  const items = JSON.parse(String(form.get('items') || '[]')) as {
+    productId: string;
+    qty: number;
+    note?: string | null;
+  }[];
   const paymentMethod = String(form.get('paymentMethod') || 'TRANSFER') as 'TRANSFER'|'COD';
   const voucherCode = String(form.get('voucher') || '').trim().toUpperCase();
 
@@ -160,7 +164,10 @@ export async function POST(req: NextRequest) {
       ? calculateFlashSalePrice(p.price, { discountPercent, startAt: now, endAt: now })
       : p.price;
     itemsTotal += unitPrice * it.qty;
-    createdItems.push({ productId: p.id, sellerId: p.sellerId, qty: it.qty, price: unitPrice });
+    const rawNote = typeof it.note === "string" ? it.note.trim() : "";
+    const note = rawNote ? rawNote.slice(0, 200) : null;
+
+    createdItems.push({ productId: p.id, sellerId: p.sellerId, qty: it.qty, price: unitPrice, note });
 
     const shipmentKey = p.warehouseId ?? 'default';
     const existing =

--- a/components/ProductPurchaseOptions.tsx
+++ b/components/ProductPurchaseOptions.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { VariantGroup } from "@/types/product";
+import { VariantSelector } from "./VariantSelector";
+import { AddToCartForm, type AddToCartFormProps } from "./AddToCartForm";
+
+const formatVariantNote = (selection: Record<string, string>) => {
+  const entries = Object.entries(selection).filter(([, value]) => value);
+  if (entries.length === 0) {
+    return "";
+  }
+  return entries.map(([name, value]) => `${name}: ${value}`).join(" • ");
+};
+
+type ProductPurchaseOptionsProps = Omit<AddToCartFormProps, "variant"> & {
+  variantGroups: VariantGroup[];
+  showSingleVariantNotice?: boolean;
+};
+
+export function ProductPurchaseOptions({
+  variantGroups,
+  showSingleVariantNotice = false,
+  ...addToCartProps
+}: ProductPurchaseOptionsProps) {
+  const [selection, setSelection] = useState<Record<string, string>>(() => {
+    const initialEntries = variantGroups.map((group) => [group.name, group.options[0] ?? ""] as const);
+    return Object.fromEntries(initialEntries);
+  });
+
+  useEffect(() => {
+    const nextEntries = variantGroups.map((group) => [group.name, group.options[0] ?? ""] as const);
+    setSelection(Object.fromEntries(nextEntries));
+  }, [variantGroups]);
+
+  const variantNote = useMemo(() => formatVariantNote(selection), [selection]);
+  const trimmedNote = variantNote.trim();
+  const selectedVariants = useMemo(() => {
+    const entries = Object.entries(selection).filter(([, value]) => value);
+    if (entries.length === 0) {
+      return undefined;
+    }
+    return Object.fromEntries(entries);
+  }, [selection]);
+
+  const handleSelectionChange = useCallback((next: Record<string, string>) => {
+    setSelection(next);
+  }, []);
+
+  return (
+    <>
+      <div className="rounded-xl border border-gray-200 bg-white p-4">
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-500">Varian</h2>
+        <VariantSelector
+          groups={variantGroups}
+          onSelectionChange={handleSelectionChange}
+        />
+        {showSingleVariantNotice ? (
+          <p className="mt-3 text-xs text-gray-500">
+            Penjual belum menambahkan detail varian, produk tersedia dalam 1 pilihan standar.
+          </p>
+        ) : null}
+        {trimmedNote ? (
+          <p className="mt-3 rounded-lg bg-sky-50 px-3 py-2 text-xs font-medium text-sky-700">
+            Catatan pesanan otomatis: {trimmedNote}
+          </p>
+        ) : null}
+      </div>
+      <div className="hidden lg:block">
+        <AddToCartForm
+          {...addToCartProps}
+          orderNote={trimmedNote || undefined}
+          selectedVariants={selectedVariants}
+        />
+      </div>
+      <AddToCartForm
+        {...addToCartProps}
+        orderNote={trimmedNote || undefined}
+        selectedVariants={selectedVariants}
+        variant="mobile"
+      />
+    </>
+  );
+}

--- a/components/VariantSelector.tsx
+++ b/components/VariantSelector.tsx
@@ -13,9 +13,14 @@ const slugify = (value: string) =>
 type VariantSelectorProps = {
   groups: VariantGroup[];
   namePrefix?: string;
+  onSelectionChange?: (selection: Record<string, string>) => void;
 };
 
-export function VariantSelector({ groups, namePrefix = "variant" }: VariantSelectorProps) {
+export function VariantSelector({
+  groups,
+  namePrefix = "variant",
+  onSelectionChange,
+}: VariantSelectorProps) {
   const safeGroups = Array.isArray(groups) ? groups.filter((group) => group.options?.length) : [];
 
   const defaultSelection = useMemo(() => {
@@ -28,6 +33,12 @@ export function VariantSelector({ groups, namePrefix = "variant" }: VariantSelec
   useEffect(() => {
     setSelected(defaultSelection);
   }, [defaultSelection]);
+
+  useEffect(() => {
+    if (typeof onSelectionChange === "function") {
+      onSelectionChange(selected);
+    }
+  }, [onSelectionChange, selected]);
 
   if (safeGroups.length === 0) {
     return (

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -262,6 +262,7 @@ model OrderItem {
   qty        Int
   price      Int
   status     ItemStatus @default(PENDING)
+  note       String?
 
   returns    ReturnRequest[]
 }


### PR DESCRIPTION
## Summary
- add a ProductPurchaseOptions client component so variant selections feed into add-to-cart actions and surface an automatic note message
- persist the selected variant note with cart items, include it in checkout payloads, and store it on order items
- show the saved notes across cart, checkout, buyer, and seller order views while extending the schema to support the new order item note field

## Testing
- npm run dev *(fails: missing database connection in local environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e736d307b8832088720d39e787048d